### PR TITLE
API: Actually supply `SHOPIFY_PRIVATE_TOKEN`.

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -72,6 +72,9 @@ let config = {
         PRISMIC_REPO: process.env.PRISMIC_REPO
     },
     serverRuntimeConfig: {
+        // Shopify
+        SHOPIFY_PRIVATE_TOKEN: process.env.SHOPIFY_PRIVATE_TOKEN,
+    
         // Prismic
         PRISMIC_TOKEN: process.env.PRISMIC_TOKEN
     },


### PR DESCRIPTION
Previously we didn't give the edge runtime access to it; now we do.