### PR TITLE
fix(storefront/search): query variants so SearchProductCard can render

### DIFF
--- a/apps/storefront/e2e/search-renders-cards.spec.ts
+++ b/apps/storefront/e2e/search-renders-cards.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+test('search results render a product card per result', async ({ page }) => {
+    await page.goto('/en-US/search/?q=t-shirt');
+
+    // Wait for the result count label to confirm the response landed.
+    const countLabel = page.getByText(/\d+ products?/i);
+    await expect(countLabel).toBeVisible();
+
+    const countText = await countLabel.textContent();
+    const expected = Number(countText?.match(/(\d+)/)?.[1] ?? 0);
+    expect(expected).toBeGreaterThan(0);
+
+    const cards = page.getByTestId('product-card-root');
+    await expect(cards).toHaveCount(expected);
+});

--- a/apps/storefront/src/api/shopify/search.regression.test.ts
+++ b/apps/storefront/src/api/shopify/search.regression.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Read the source file directly to introspect the GraphQL query shape WITHOUT
+// importing search.ts, which transitively pulls in @/api/_loaders → RawShop and
+// requires MONGODB_URI at module-load time (would explode in unit tests).
+const searchSource = readFileSync(
+    join(process.cwd(), 'apps/storefront/src/api/shopify/search.ts'),
+    'utf8',
+);
+
+describe('SEARCH_PRODUCTS_QUERY — Phase 1 regression', () => {
+    it('spreads the ProductMinimal fragment so SearchProductCard sees variants', () => {
+        expect(searchSource).toMatch(/\.{3}ProductMinimal/);
+        expect(searchSource).toMatch(/PRODUCT_FRAGMENT_MINIMAL/);
+    });
+
+    it('imports the shared fragment from product-fragments', () => {
+        expect(searchSource).toMatch(/from\s+'@\/api\/shopify\/product-fragments'/);
+    });
+});

--- a/apps/storefront/src/api/shopify/search.ts
+++ b/apps/storefront/src/api/shopify/search.ts
@@ -7,12 +7,14 @@ import { cacheLife, cacheTag } from 'next/cache';
 import { Shop } from '@/api/_loaders';
 import type { Product, ProductFilters } from '@/api/product';
 import { ShopifyApolloApiClient } from '@/api/shopify';
+import { PRODUCT_FRAGMENT_MINIMAL } from '@/api/shopify/product-fragments';
 import { cache } from '@/cache';
 import type { AbstractApi } from '@/utils/abstract-api';
 import { Locale } from '@/utils/locale';
 import { unsafe_cast } from '@/utils/unsafe-cast';
 
-const SEARCH_PRODUCTS_QUERY = graphql(`
+export const SEARCH_PRODUCTS_QUERY = graphql(
+    `
     query searchProducts($query: String!, $first: Int, $type: [SearchType!]) {
         search(query: $query, first: $first, types: $type) {
             totalCount
@@ -34,48 +36,15 @@ const SEARCH_PRODUCTS_QUERY = graphql(`
             edges {
                 node {
                     ... on Product {
-                        id
-                        handle
-                        title
-                        vendor
-                        productType
-                        availableForSale
-                        trackingParameters
-                        featuredImage {
-                            id
-                            url(transform: { preferredContentType: WEBP })
-                            altText
-                            width
-                            height
-                        }
-                        images(first: 1) {
-                            edges {
-                                node {
-                                    id
-                                    url(transform: { preferredContentType: WEBP })
-                                    altText
-                                    width
-                                    height
-                                }
-                            }
-                        }
-                        tags
-                        priceRange {
-                            minVariantPrice {
-                                amount
-                                currencyCode
-                            }
-                            maxVariantPrice {
-                                amount
-                                currencyCode
-                            }
-                        }
+                        ...ProductMinimal
                     }
                 }
             }
         }
     }
-`);
+`,
+    [PRODUCT_FRAGMENT_MINIMAL],
+);
 
 export const SearchApi = async ({
     client,

--- a/apps/storefront/src/app/[domain]/[locale]/search/search-content-gate.regression.test.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/search/search-content-gate.regression.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/product-card', () => {
+    const ProductCard = () => <div data-testid="product-card" />;
+    ProductCard.skeleton = () => <div data-testid="product-card-skeleton" />;
+    return { default: ProductCard };
+});
+
+vi.mock('@/components/products/search-product-card', () => ({
+    __esModule: true,
+    default: ({ data }: { data: { handle: string } }) => (
+        <article data-testid="product-card-root">{data.handle}</article>
+    ),
+}));
+
+vi.mock('./search-content', () => ({
+    default: ({ productCards }: { productCards: React.ReactNode[] }) => (
+        <div data-testid="search-content">{productCards}</div>
+    ),
+}));
+
+import { render, screen } from '@/utils/test/react';
+import SearchContentGate from './search-content-gate';
+
+const shop = { id: 'shop-1', domain: 'shop.example.com' } as never;
+const locale = { code: 'en-US' } as never;
+const i18n = {} as never;
+
+describe('SearchContentGate — phase 1 regression', () => {
+    it('renders one product-card-root per result returned by cachedSearch', () => {
+        const data = {
+            products: [
+                {
+                    id: 'gid://shopify/Product/1',
+                    handle: 'a',
+                    variants: { edges: [{ node: { id: 'v1', availableForSale: true } }] },
+                } as never,
+                {
+                    id: 'gid://shopify/Product/2',
+                    handle: 'b',
+                    variants: { edges: [{ node: { id: 'v2', availableForSale: true } }] },
+                } as never,
+                {
+                    id: 'gid://shopify/Product/3',
+                    handle: 'c',
+                    variants: { edges: [{ node: { id: 'v3', availableForSale: true } }] },
+                } as never,
+            ],
+            productFilters: [],
+            totalCount: 3,
+        };
+
+        render(<SearchContentGate shop={shop} locale={locale} i18n={i18n} data={data} showFilters={false} />);
+
+        expect(screen.getAllByTestId('product-card-root')).toHaveLength(3);
+    });
+});


### PR DESCRIPTION
## Summary
- **Production regression**: search results returned `N PRODUCTS` but rendered zero cards in DOM. Root cause: the inline `SEARCH_PRODUCTS_QUERY` in `apps/storefront/src/api/shopify/search.ts` omitted `variants`, and `SearchProductCard` short-circuits to `null` when `data.variants.edges[0]?.node` is missing. The `unsafe_cast<Product>(item.node)` at `search.ts:118` was masking the missing field at the type level.
- Swap the inline selection for the shared `PRODUCT_FRAGMENT_MINIMAL` already used by the collection page. Same product shape across all surfaces.
- Add unit + e2e smoke tests so the regression can't recur quietly.

This is **Phase 1** of the product-card redesign tracked in `.specs/2026-05-26-product-card-redesign/spec.md` and `plan.md`. It ships standalone; Phases 2-6 (chassis/primitives/picker/Tailwind migration/surface arrows) stack on top.

## Test plan
- [x] `pnpm test --project @nordcom/commerce-storefront -- search-content-gate.regression` — locks fan-out (1 card per result).
- [x] `pnpm test --project @nordcom/commerce-storefront -- search.regression` — introspects the query source to confirm the fragment spread + import.
- [x] `pnpm typecheck` (storefront) — clean.
- [ ] CI: `pnpm test:e2e -- search-renders-cards` — visits \`/en-US/search/?q=t-shirt\`, asserts \`getAllByTestId('product-card-root').length === N PRODUCTS\`.
- [ ] Manual: visit \`https://beta.pouched.de/en-US/search/?q=t-shirt\` post-merge; cards should render.

Note: pre-existing `apps/storefront/src/api/_loaders.test.ts` failures (mongo env var) are not caused by this PR — they show up on master too.