### PR TITLE
feat(storefront/product-card): foundation — tokens, registries, presets, provider

### DIFF
--- a/apps/storefront/e2e/search-renders-cards.spec.ts
+++ b/apps/storefront/e2e/search-renders-cards.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+test('search results render a product card per result', async ({ page }) => {
+    await page.goto('/en-US/search/?q=t-shirt');
+
+    // Wait for the result count label to confirm the response landed.
+    const countLabel = page.getByText(/\d+ products?/i);
+    await expect(countLabel).toBeVisible();
+
+    const countText = await countLabel.textContent();
+    const expected = Number(countText?.match(/(\d+)/)?.[1] ?? 0);
+    expect(expected).toBeGreaterThan(0);
+
+    const cards = page.getByTestId('product-card-root');
+    await expect(cards).toHaveCount(expected);
+});

--- a/apps/storefront/src/api/shopify/search.regression.test.ts
+++ b/apps/storefront/src/api/shopify/search.regression.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Read the source file directly to introspect the GraphQL query shape WITHOUT
+// importing search.ts, which transitively pulls in @/api/_loaders → RawShop and
+// requires MONGODB_URI at module-load time (would explode in unit tests).
+const searchSource = readFileSync(
+    join(process.cwd(), 'apps/storefront/src/api/shopify/search.ts'),
+    'utf8',
+);
+
+describe('SEARCH_PRODUCTS_QUERY — Phase 1 regression', () => {
+    it('spreads the ProductMinimal fragment so SearchProductCard sees variants', () => {
+        expect(searchSource).toMatch(/\.{3}ProductMinimal/);
+        expect(searchSource).toMatch(/PRODUCT_FRAGMENT_MINIMAL/);
+    });
+
+    it('imports the shared fragment from product-fragments', () => {
+        expect(searchSource).toMatch(/from\s+'@\/api\/shopify\/product-fragments'/);
+    });
+});

--- a/apps/storefront/src/api/shopify/search.ts
+++ b/apps/storefront/src/api/shopify/search.ts
@@ -7,12 +7,14 @@ import { cacheLife, cacheTag } from 'next/cache';
 import { Shop } from '@/api/_loaders';
 import type { Product, ProductFilters } from '@/api/product';
 import { ShopifyApolloApiClient } from '@/api/shopify';
+import { PRODUCT_FRAGMENT_MINIMAL } from '@/api/shopify/product-fragments';
 import { cache } from '@/cache';
 import type { AbstractApi } from '@/utils/abstract-api';
 import { Locale } from '@/utils/locale';
 import { unsafe_cast } from '@/utils/unsafe-cast';
 
-const SEARCH_PRODUCTS_QUERY = graphql(`
+export const SEARCH_PRODUCTS_QUERY = graphql(
+    `
     query searchProducts($query: String!, $first: Int, $type: [SearchType!]) {
         search(query: $query, first: $first, types: $type) {
             totalCount
@@ -34,48 +36,15 @@ const SEARCH_PRODUCTS_QUERY = graphql(`
             edges {
                 node {
                     ... on Product {
-                        id
-                        handle
-                        title
-                        vendor
-                        productType
-                        availableForSale
-                        trackingParameters
-                        featuredImage {
-                            id
-                            url(transform: { preferredContentType: WEBP })
-                            altText
-                            width
-                            height
-                        }
-                        images(first: 1) {
-                            edges {
-                                node {
-                                    id
-                                    url(transform: { preferredContentType: WEBP })
-                                    altText
-                                    width
-                                    height
-                                }
-                            }
-                        }
-                        tags
-                        priceRange {
-                            minVariantPrice {
-                                amount
-                                currencyCode
-                            }
-                            maxVariantPrice {
-                                amount
-                                currencyCode
-                            }
-                        }
+                        ...ProductMinimal
                     }
                 }
             }
         }
     }
-`);
+`,
+    [PRODUCT_FRAGMENT_MINIMAL],
+);
 
 export const SearchApi = async ({
     client,

--- a/apps/storefront/src/app/[domain]/[locale]/search/search-content-gate.regression.test.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/search/search-content-gate.regression.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/product-card', () => {
+    const ProductCard = () => <div data-testid="product-card" />;
+    ProductCard.skeleton = () => <div data-testid="product-card-skeleton" />;
+    return { default: ProductCard };
+});
+
+vi.mock('@/components/products/search-product-card', () => ({
+    __esModule: true,
+    default: ({ data }: { data: { handle: string } }) => (
+        <article data-testid="product-card-root">{data.handle}</article>
+    ),
+}));
+
+vi.mock('./search-content', () => ({
+    default: ({ productCards }: { productCards: React.ReactNode[] }) => (
+        <div data-testid="search-content">{productCards}</div>
+    ),
+}));
+
+import { render, screen } from '@/utils/test/react';
+import SearchContentGate from './search-content-gate';
+
+const shop = { id: 'shop-1', domain: 'shop.example.com' } as never;
+const locale = { code: 'en-US' } as never;
+const i18n = {} as never;
+
+describe('SearchContentGate — phase 1 regression', () => {
+    it('renders one product-card-root per result returned by cachedSearch', () => {
+        const data = {
+            products: [
+                {
+                    id: 'gid://shopify/Product/1',
+                    handle: 'a',
+                    variants: { edges: [{ node: { id: 'v1', availableForSale: true } }] },
+                } as never,
+                {
+                    id: 'gid://shopify/Product/2',
+                    handle: 'b',
+                    variants: { edges: [{ node: { id: 'v2', availableForSale: true } }] },
+                } as never,
+                {
+                    id: 'gid://shopify/Product/3',
+                    handle: 'c',
+                    variants: { edges: [{ node: { id: 'v3', availableForSale: true } }] },
+                } as never,
+            ],
+            productFilters: [],
+            totalCount: 3,
+        };
+
+        render(<SearchContentGate shop={shop} locale={locale} i18n={i18n} data={data} showFilters={false} />);
+
+        expect(screen.getAllByTestId('product-card-root')).toHaveLength(3);
+    });
+});

--- a/apps/storefront/src/app/globals.css
+++ b/apps/storefront/src/app/globals.css
@@ -178,68 +178,94 @@ html:root {
     /* Soft warm accent surface; used by chip hover, overlay row hover etc. */
     --accent-soft: #f3eedc;
 
-    /* Product-card tokens — soft-boxed premium chassis (spec: 2026-05-26-product-card-fix-design.md §Tokens).
-     * Neutral warm palette; brand accent only enters via CTA bg + active swatch ring.
-     * Mobile-first defaults; md+ overrides below. Tenant theming overrides per-shop on [data-shop="..."]. */
+    /* Product card tokens.
+     * Phase 2 of .specs/2026-05-26-product-card-redesign/ — additive only.
+     * Tokens marked LEGACY are referenced by pre-Phase-3 primitives that get
+     * rewritten or deleted in Phase 3; they will be removed then.
+     * Phase 3+ will read --block-border-radius* / --block-padding / --block-spacer
+     * for spacing and Tailwind type-scale utilities for typography. */
+
+    /* Chassis */
     --product-card-bg: #ffffff;
-    --product-card-border-color: #ece6d4; /* warm hairline */
+    --product-card-border-color: #ece6d4;
     --product-card-border-width: 1px;
-    --product-card-radius: 12px;
-    --product-card-padding: 10px;
-    --product-card-gap: 8px;
+    --product-card-radius: 12px;                 /* LEGACY */
+    --product-card-padding: 10px;                /* LEGACY */
+    --product-card-gap: 8px;                     /* LEGACY */
     --product-card-shadow: 0 1px 0 rgb(20 17 11 / 2%), 0 1px 2px rgb(20 17 11 / 4%);
     --product-card-shadow-hover: 0 1px 0 rgb(20 17 11 / 2%), 0 10px 24px -12px rgb(20 17 11 / 22%);
+    --product-card-min-width: 200px;
+    --product-card-max-width: 240px;
+    --product-card-grid-align: start;
+    --product-card-search-image-width: 72px;
 
-    --product-card-image-bg: #faf7f0; /* used inside the boxed white card */
-    --product-card-image-bg-bare: #f3eedc; /* used by bare so the tile stays visible on warm pages */
-    --product-card-image-radius: 8px;
-    --product-card-image-padding: 12px;
-
+    /* Image */
+    --product-card-image-bg: #faf7f0;
+    --product-card-image-bg-bare: #f3eedc;
+    --product-card-image-radius: 8px;            /* LEGACY */
+    --product-card-image-padding: 12px;          /* LEGACY */
+    --product-card-image-fit: cover;
+    --product-card-image-hover-swap: on;
+    --product-card-image-sizes: (max-width: 768px) 50vw, 240px;
     --aspect-product-card-vertical: 4 / 5;
-    --aspect-product-card-horizontal: 4 / 5; /* matches typical apparel; clothes products no longer waste space */
-    --aspect-product-card-horizontal-square: 1 / 1; /* opt-in for square-product surfaces (cart-drawer accessories) */
-    --aspect-product-card-micro: 1 / 1;
+    --aspect-product-card-horizontal: 4 / 5;
+    --aspect-product-card-horizontal-square: 1 / 1; /* LEGACY (only horizontal layout in Phase 3+) */
+    --aspect-product-card-micro: 1 / 1;          /* LEGACY (micro layout deleted in Phase 3) */
 
-    --product-card-vendor-color: #6b6555; /* tightened from #8b8475 — clears WCAG AA at 11px on white */
-    --product-card-vendor-size: 11px;
+    /* Typography */
+    --product-card-vendor-color: #6b6555;
+    --product-card-vendor-size: 11px;            /* LEGACY */
     --product-card-title-color: #14110b;
-    --product-card-title-size: 14px;
-    --product-card-title-weight: 600;
+    --product-card-title-size: 14px;             /* LEGACY */
+    --product-card-title-weight: 600;            /* LEGACY */
     --product-card-title-line-clamp: 2;
-
     --product-card-price-color: #14110b;
-    --product-card-price-size: 15px;
-    --product-card-price-weight: 700;
-    --product-card-compare-color: #6b6555; /* same a11y tightening */
+    --product-card-price-size: 15px;             /* LEGACY */
+    --product-card-price-weight: 700;            /* LEGACY */
+    --product-card-compare-color: #6b6555;
+    --product-card-urgency-color: #b54a2a;
+    --product-card-urgency-threshold: 5;
+    --product-card-eyebrow-tracking: 0.14em;
 
-    --product-card-swatch-size: 18px;
+    /* Swatch */
+    --product-card-swatch-size: 18px;            /* LEGACY value; Phase 3 chassis reads 16px */
     --product-card-swatch-gap: 5px;
     --product-card-swatch-ring-color: #14110b;
-    --product-card-swatch-hit-padding: 6px; /* 18px visual + 2×6px padding = 30px hit target ≥ WCAG 2.5.5 */
+    --product-card-swatch-hit-padding: 6px;      /* LEGACY value; Phase 3 chassis reads 10px */
 
+    /* Chip + More */
     --product-card-chip-bg: #ffffff;
     --product-card-chip-color: #14110b;
     --product-card-chip-border: #ece6d4;
     --product-card-chip-active-bg: #14110b;
     --product-card-chip-active-color: #ffffff;
-    --product-card-chip-padding-y: 6px;
-    --product-card-chip-padding-x: 10px;
-
+    --product-card-chip-padding-y: 6px;          /* LEGACY */
+    --product-card-chip-padding-x: 10px;         /* LEGACY */
     --product-card-more-bg: #f3eedc;
     --product-card-more-color: #4a463b;
-    --product-card-more-size: 11px;
-    --product-card-more-weight: 600;
-    --product-card-more-min-size: 24px;
+    --product-card-more-size: 11px;              /* LEGACY */
+    --product-card-more-weight: 600;             /* LEGACY */
+    --product-card-more-min-size: 24px;          /* LEGACY */
 
+    /* CTA */
     --product-card-cta-bg: #14110b;
     --product-card-cta-color: #ffffff;
-    --product-card-cta-radius: 8px;
-    --product-card-cta-padding-y: 11px;
+    --product-card-cta-radius: 8px;              /* LEGACY */
+    --product-card-cta-padding-y: 11px;          /* LEGACY */
+    --product-card-cta-height: 36px;             /* LEGACY (used by product-card-actions-client) */
+    --product-card-cta-placement: float-pill;
+    --product-card-cta-pill-position: top-right;
+    --product-card-cta-pill-label: "";
+    --product-card-cta-pill-icon: "+";
+    --product-card-cta-pill-reveal: always;
+    --product-card-cta-inline-style: solid;
+    --product-card-fast-path-dot: #2f7d4a;
+    --product-card-fast-path-single-variant: on;
 
-    --product-card-urgency-color: #b54a2a;
-    /* Numeric token; read in JS via getComputedStyle. */
-    --product-card-urgency-threshold: 5;
+    /* Picker */
+    --product-card-quick-add-presentation: auto;
 
+    /* Overlay (LEGACY — product-card-overlay primitive deleted in Phase 3) */
     --product-card-overlay-bg: #ffffff;
     --product-card-overlay-radius: 12px;
     --product-card-overlay-border-color: #ece6d4;
@@ -248,11 +274,35 @@ html:root {
     --product-card-overlay-max-height: 320px;
     --product-card-overlay-padding: 14px;
 
+    /* Out-of-stock */
+    --product-card-oos-opacity: 0.7;
+    --product-card-oos-image-saturate: 0.85;
+
+    /* Motion */
+    --product-card-motion-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+    --product-card-motion-fast: 80ms;
+    --product-card-motion-base: 160ms;
+    --product-card-motion-picker-in: 220ms;
+    --product-card-motion-picker-out: 180ms;
+    /* LEGACY motion tokens — pre-Phase-3 primitives read these names. */
     --product-card-motion-hover-duration: 200ms;
     --product-card-motion-hover-ease: cubic-bezier(0.2, 0.8, 0.2, 1);
     --product-card-motion-image-swap-duration: 400ms;
     --product-card-motion-overlay-in-duration: 180ms;
     --product-card-motion-overlay-in-ease: cubic-bezier(0.32, 0.72, 0, 1);
+
+    /* Sale */
+    --product-card-sale-style: strike-only;
+    --product-card-sale-strike-color: currentColor;
+    --product-card-sale-strike-angle: -8deg;
+    --product-card-sale-strike-extend: 2px;
+    --product-card-sale-current-color: #b54a2a;
+    --product-card-sale-show-savings-line: off;
+    --product-card-sale-badge-style: default;
+    --product-card-sale-badge-position: top-left;
+    --product-card-sale-badge-text: "−{n}%";
+    --product-card-sale-badge-min-discount: 11;
+    --product-card-sale-badge-allow-overlap: false;
 }
 
 @media (min-width: 48em) {

--- a/apps/storefront/src/components/product-card/cta/registry.test.ts
+++ b/apps/storefront/src/components/product-card/cta/registry.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getProductCardCta, registerProductCardCta } from './registry';
+
+describe('CTA registry', () => {
+  it('returns the registered component when looked up by name', () => {
+    const FakeCta = () => null;
+    registerProductCardCta('fake-test-key', FakeCta);
+    expect(getProductCardCta('fake-test-key')).toBe(FakeCta);
+  });
+
+  it('falls back to float-pill when the name is unknown', () => {
+    const FloatPill = () => null;
+    registerProductCardCta('float-pill', FloatPill);
+    expect(getProductCardCta('absent')).toBe(FloatPill);
+  });
+});

--- a/apps/storefront/src/components/product-card/cta/registry.ts
+++ b/apps/storefront/src/components/product-card/cta/registry.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import type { ProductCardCtaComponent } from './types';
+
+const registry = new Map<string, ProductCardCtaComponent>();
+
+export function registerProductCardCta(name: string, component: ProductCardCtaComponent) {
+  registry.set(name, component);
+}
+
+export function getProductCardCta(name: string): ProductCardCtaComponent {
+  const found = registry.get(name);
+  if (found) return found;
+  const fallback = registry.get('float-pill');
+  if (!fallback) throw new Error('product-card CTA registry has no float-pill fallback registered');
+  return fallback;
+}

--- a/apps/storefront/src/components/product-card/cta/types.ts
+++ b/apps/storefront/src/components/product-card/cta/types.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import type { ComponentType } from 'react';
+
+export type ProductCardCtaProps = {
+  productHandle: string;
+  seedVariantId: string;
+  isSingleBuyable: boolean;
+  isOpen: boolean;
+  onActivate: () => void;
+  onAdd: () => void;
+};
+
+export type ProductCardCtaComponent = ComponentType<ProductCardCtaProps>;

--- a/apps/storefront/src/components/product-card/picker/registry.test.ts
+++ b/apps/storefront/src/components/product-card/picker/registry.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getProductCardPicker, registerProductCardPicker } from './registry';
+
+describe('picker registry', () => {
+    it('returns the registered component', () => {
+        const FakePicker = () => null;
+        registerProductCardPicker('fake-test-shape', FakePicker);
+        expect(getProductCardPicker('fake-test-shape')).toBe(FakePicker);
+    });
+
+    it('falls back to float when the name is unknown', () => {
+        const Float = () => null;
+        registerProductCardPicker('float', Float);
+        expect(getProductCardPicker('absent')).toBe(Float);
+    });
+});

--- a/apps/storefront/src/components/product-card/picker/registry.ts
+++ b/apps/storefront/src/components/product-card/picker/registry.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import type { ProductCardPickerComponent } from './types';
+
+const registry = new Map<string, ProductCardPickerComponent>();
+
+export function registerProductCardPicker(name: string, component: ProductCardPickerComponent) {
+    registry.set(name, component);
+}
+
+export function getProductCardPicker(name: string): ProductCardPickerComponent {
+    const found = registry.get(name);
+    if (found) return found;
+    const fallback = registry.get('float');
+    if (!fallback) throw new Error('product-card picker registry has no float fallback registered');
+    return fallback;
+}

--- a/apps/storefront/src/components/product-card/picker/types.ts
+++ b/apps/storefront/src/components/product-card/picker/types.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import type { ComponentType } from 'react';
+import type { Product } from '@/api/product';
+import type { Locale, LocaleDictionary } from '@/utils/locale';
+
+export type ProductCardPickerProps = {
+    product: Product;
+    locale: Locale;
+    i18n: LocaleDictionary;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+};
+
+export type ProductCardPickerComponent = ComponentType<ProductCardPickerProps>;

--- a/apps/storefront/src/components/product-card/presets.test.ts
+++ b/apps/storefront/src/components/product-card/presets.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { SURFACE_PRESETS } from './presets';
+
+describe('SURFACE_PRESETS', () => {
+    it('exposes collection, recommendation, search', () => {
+        expect(Object.keys(SURFACE_PRESETS).sort()).toEqual(['collection', 'recommendation', 'search']);
+    });
+
+    it('collection + recommendation use vertical/boxed/float-pill/auto', () => {
+        for (const k of ['collection', 'recommendation'] as const) {
+            expect(SURFACE_PRESETS[k]).toEqual({
+                layout: 'vertical',
+                chrome: 'boxed',
+                ctaPlacement: 'float-pill',
+                pickerPresentation: 'auto'
+            });
+        }
+    });
+
+    it('search uses horizontal/boxed', () => {
+        expect(SURFACE_PRESETS.search.layout).toBe('horizontal');
+        expect(SURFACE_PRESETS.search.chrome).toBe('boxed');
+    });
+});

--- a/apps/storefront/src/components/product-card/presets.ts
+++ b/apps/storefront/src/components/product-card/presets.ts
@@ -1,0 +1,34 @@
+import 'server-only';
+
+export type ProductCardLayout = 'vertical' | 'horizontal';
+export type ProductCardChrome = 'boxed' | 'frameless';
+export type ProductCardCtaPlacement = string;
+export type ProductCardPickerPresentation = 'auto' | 'float' | 'sheet' | 'inline';
+
+export type ProductCardSurfacePreset = {
+    layout: ProductCardLayout;
+    chrome: ProductCardChrome;
+    ctaPlacement: ProductCardCtaPlacement;
+    pickerPresentation: ProductCardPickerPresentation;
+};
+
+export const SURFACE_PRESETS = {
+    collection: {
+        layout: 'vertical',
+        chrome: 'boxed',
+        ctaPlacement: 'float-pill',
+        pickerPresentation: 'auto'
+    },
+    recommendation: {
+        layout: 'vertical',
+        chrome: 'boxed',
+        ctaPlacement: 'float-pill',
+        pickerPresentation: 'auto'
+    },
+    search: {
+        layout: 'horizontal',
+        chrome: 'boxed',
+        ctaPlacement: 'float-pill',
+        pickerPresentation: 'auto'
+    }
+} as const satisfies Record<string, ProductCardSurfacePreset>;

--- a/apps/storefront/src/components/product-card/primitives/product-card-options-provider.test.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-options-provider.test.tsx
@@ -1,0 +1,60 @@
+// apps/storefront/src/components/product-card/primitives/product-card-options-provider.test.tsx
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  ProductCardOptionsProvider,
+  usePickerOpen,
+  useVariantSelection,
+} from './product-card-options-provider';
+
+const product = {
+  id: 'gid://shopify/Product/1',
+  handle: 'tee',
+  variants: { edges: [{ node: { id: 'v1', availableForSale: true, selectedOptions: [{ name: 'Size', value: 'M' }] } }] },
+} as never;
+
+describe('ProductCardOptionsProvider', () => {
+  it('reads initial seed variant id', () => {
+    const { result } = renderHook(() => useVariantSelection(), {
+      wrapper: ({ children }) => (
+        <ProductCardOptionsProvider product={product} seedVariantId="v1" isSingleBuyable={true}>
+          {children}
+        </ProductCardOptionsProvider>
+      ),
+    });
+    expect(result.current?.selectedVariantId).toBe('v1');
+  });
+
+  it('exposes isSingleBuyable to the picker-open context', () => {
+    const { result } = renderHook(() => usePickerOpen(), {
+      wrapper: ({ children }) => (
+        <ProductCardOptionsProvider product={product} seedVariantId="v1" isSingleBuyable={true}>
+          {children}
+        </ProductCardOptionsProvider>
+      ),
+    });
+    expect(result.current?.isSingleBuyable).toBe(true);
+    expect(result.current?.open).toBe(false);
+  });
+
+  it('toggling picker open does not change selection identity', () => {
+    let selectionRefBefore: unknown;
+    let selectionRefAfter: unknown;
+    const Probe = () => {
+      const sel = useVariantSelection();
+      selectionRefBefore ??= sel;
+      selectionRefAfter = sel;
+      return null;
+    };
+    const { result } = renderHook(() => usePickerOpen(), {
+      wrapper: ({ children }) => (
+        <ProductCardOptionsProvider product={product} seedVariantId="v1" isSingleBuyable={false}>
+          <Probe />
+          {children}
+        </ProductCardOptionsProvider>
+      ),
+    });
+    act(() => result.current?.setOpen(true));
+    expect(selectionRefAfter).toBe(selectionRefBefore); // selection context is referentially stable
+  });
+});

--- a/apps/storefront/src/components/product-card/primitives/product-card-options-provider.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-options-provider.tsx
@@ -1,0 +1,58 @@
+// apps/storefront/src/components/product-card/primitives/product-card-options-provider.tsx
+'use client';
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import type { Product } from '@/api/product';
+
+type VariantSelectionValue = {
+  product: Product;
+  selectedVariantId: string;
+  selectVariant: (variantId: string) => void;
+};
+
+type PickerOpenValue = {
+  isSingleBuyable: boolean;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};
+
+const VariantSelectionContext = createContext<VariantSelectionValue | null>(null);
+const PickerOpenContext = createContext<PickerOpenValue | null>(null);
+
+export type ProductCardOptionsProviderProps = {
+  product: Product;
+  seedVariantId: string;
+  isSingleBuyable: boolean;
+  children: ReactNode;
+};
+
+export function ProductCardOptionsProvider({
+  product,
+  seedVariantId,
+  isSingleBuyable,
+  children,
+}: ProductCardOptionsProviderProps) {
+  const [selectedVariantId, setSelectedVariantId] = useState(seedVariantId);
+  const [open, setOpen] = useState(false);
+
+  const selectVariant = useCallback((next: string) => setSelectedVariantId(next), []);
+
+  const selectionValue = useMemo<VariantSelectionValue>(
+    () => ({ product, selectedVariantId, selectVariant }),
+    [product, selectedVariantId, selectVariant],
+  );
+
+  const pickerValue = useMemo<PickerOpenValue>(
+    () => ({ isSingleBuyable, open, setOpen }),
+    [isSingleBuyable, open],
+  );
+
+  return (
+    <VariantSelectionContext.Provider value={selectionValue}>
+      <PickerOpenContext.Provider value={pickerValue}>{children}</PickerOpenContext.Provider>
+    </VariantSelectionContext.Provider>
+  );
+}
+
+export const useVariantSelection = () => useContext(VariantSelectionContext);
+export const usePickerOpen = () => useContext(PickerOpenContext);


### PR DESCRIPTION
## Summary
**Phase 2** of the product-card redesign tracked in \`.specs/2026-05-26-product-card-redesign/\`. **Additive only** — no primitives rewritten yet, no visual change for end users. Stacked on Phase 1 (#1916).

Lands the scaffolding the rewrite in Phase 3 will plug into:
- New spec-local tokens in \`globals.css\` (sizing, CTA placement, picker presentation, motion, sale state, OOS, eyebrow tracking). Pre-existing tokens kept and marked \`LEGACY\` — they get purged in Phase 3 as the primitives that reference them are rewritten.
- \`product-card/cta/\` — placement registry + types (module-level Map, \`register\` / \`get\`, falls back to \`float-pill\`).
- \`product-card/picker/\` — picker shape registry + types (falls back to \`float\`).
- \`product-card/presets.ts\` — \`SURFACE_PRESETS\` constant for Collection / Recommendation / Search.
- \`product-card/primitives/product-card-options-provider.tsx\` — two-context provider (\`VariantSelectionContext\` + \`PickerOpenContext\`) so picker open/close toggles don't re-render variant consumers.

Five atomic commits, one per task in the plan.

## Test plan
- [x] \`pnpm test --project @nordcom/commerce-storefront -- product-card/cta/registry\` — register / lookup / fallback.
- [x] \`pnpm test --project @nordcom/commerce-storefront -- product-card/picker/registry\` — same shape, different concern.
- [x] \`pnpm test --project @nordcom/commerce-storefront -- product-card/presets\` — preset surface contents.
- [x] \`pnpm test --project @nordcom/commerce-storefront -- product-card-options-provider\` — selection state, single-buyable detection, referential stability of selection context across picker-open toggles.
- [x] \`pnpm typecheck\` — clean.

## Notes
- Pre-existing \`apps/storefront/src/api/_loaders.test.ts\` failures (mongo env var) appear on master too — not caused by this PR.
- Phase 3 will wire these scaffolds into actual primitives.