### PR TITLE
docs(utils): backfill jsdoc on functions and components

### DIFF
--- a/.specs/2026-05-27-jsdoc-coverage-retrofit/generator-prompt.md
+++ b/.specs/2026-05-27-jsdoc-coverage-retrofit/generator-prompt.md
@@ -14,10 +14,11 @@ You are the JSDoc generator subagent for `<PACKAGE_PATH>`. Read the spec at `.sp
 
 Inside the worktree:
 
-1. Confirm clean working tree: `git status --porcelain` → must be empty.
-2. Confirm on the right branch: `git rev-parse --abbrev-ref HEAD` → must equal `docs/jsdoc-<PACKAGE_SLUG>`.
-3. Baseline typecheck: `pnpm --filter <PACKAGE_NPM_NAME> typecheck`. Must pass.
-4. Baseline lint: `pnpm --filter <PACKAGE_NPM_NAME> lint`. Must pass.
+1. Install deps: `pnpm install --prefer-offline --frozen-lockfile`. A fresh worktree has no `node_modules`; install reuses the central store, so it's usually quick.
+2. Confirm clean working tree: `git status --porcelain` → must be empty (ignore `node_modules/` lines if any leak through).
+3. Confirm on the right branch: `git rev-parse --abbrev-ref HEAD` → must equal `docs/jsdoc-<PACKAGE_SLUG>`.
+4. Baseline typecheck: `pnpm --filter <PACKAGE_NPM_NAME> typecheck`. Must pass.
+5. Baseline lint: `pnpm --filter <PACKAGE_NPM_NAME> lint`. Must pass.
 
 If any precondition fails, abort immediately and report the failure. Do not edit anything. Fixing pre-existing issues is out of scope for this campaign.
 

--- a/.specs/2026-05-27-jsdoc-coverage-retrofit/generator-prompt.md
+++ b/.specs/2026-05-27-jsdoc-coverage-retrofit/generator-prompt.md
@@ -30,15 +30,23 @@ If any precondition fails, abort immediately and report the failure. Do not edit
    - For each in-scope symbol (per spec § "In scope (the what)"), classify tier using the Tier-1 rule (re-exported from barrel or `exports` map → Tier 1; else → Tier 2).
    - Insert the JSDoc block above the symbol using `Edit` (never `Write`). Match the spec's template for the symbol's tier and shape (function / React component / server action / class / etc.).
    - If the symbol already has a JSDoc block, leave it alone — cleanup of existing blocks is out of scope.
+   - Maintain running counts of Tier-1 symbols documented, Tier-2 symbols documented, and files touched. Use them to fill the `<N>` placeholders in Step 8's PR body.
 4. After all files edited:
    - Run `pnpm --filter <PACKAGE_NPM_NAME> typecheck`. Must pass. If it fails, the cause is your edits — fix or revert before continuing.
    - Run `pnpm --filter <PACKAGE_NPM_NAME> lint --write` to absorb Biome formatting drift.
    - Run `git diff --stat` and visually confirm: only `*.ts` / `*.tsx` files under `<PACKAGE_PATH>/src/`, no code changes other than JSDoc insertions and whitespace. If you see any non-JSDoc line change, abort and surface the diff.
-5. Generate a changeset only if `<PACKAGE_NPM_NAME>` is NOT in `.changeset/config.json#ignore`:
-   - Run `pnpm changeset` interactively-equivalent: write `.changeset/<random-slug>.md` directly with frontmatter `'<PACKAGE_NPM_NAME>': patch` and body `Backfill JSDoc on public/internal symbols.`
+5. Generate a changeset only if `<PACKAGE_NPM_NAME>` is NOT matched by any glob pattern in `.changeset/config.json#ignore` (patterns use minimatch semantics — `@nordcom/*` matches `@nordcom/commerce-errors`, the leading `!@nordcom/cart-*` re-includes cart packages):
+   - Write `.changeset/<random-slug>.md` directly (the interactive `pnpm changeset` flow doesn't work in a subagent context). File contents:
+     ```
+     ---
+     '<PACKAGE_NPM_NAME>': patch
+     ---
+
+     Backfill JSDoc on public/internal symbols.
+     ```
 6. Stage and commit:
    ```bash
-   git add <PACKAGE_PATH>/ .changeset/
+   git add <PACKAGE_PATH>/src/ .changeset/
    git commit -m "docs(<COMMIT_SCOPE>): backfill jsdoc on functions and components."
    ```
 7. Push: `git push -u origin docs/jsdoc-<PACKAGE_SLUG>`

--- a/.specs/2026-05-27-jsdoc-coverage-retrofit/generator-prompt.md
+++ b/.specs/2026-05-27-jsdoc-coverage-retrofit/generator-prompt.md
@@ -1,0 +1,68 @@
+# JSDoc Generator — `<PACKAGE_PATH>`
+
+You are the JSDoc generator subagent for `<PACKAGE_PATH>`. Read the spec at `.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md` in full before doing anything else. It defines the tier rules, content requirements, templates, and anti-patterns you must follow. This prompt does NOT restate them — it parameterizes your run.
+
+## Run parameters
+
+- Package path: `<PACKAGE_PATH>` (e.g., `packages/errors`, `apps/admin`)
+- Package npm name: `<PACKAGE_NPM_NAME>` (the `name` field from `<PACKAGE_PATH>/package.json`)
+- Worktree path: `<WORKTREE_PATH>` (already created by orchestrator; cd here before any git ops)
+- Branch name: `docs/jsdoc-<PACKAGE_SLUG>`
+- Commit scope: `<COMMIT_SCOPE>` (e.g., `errors`, `cart-core`, `admin`)
+
+## Precondition (mandatory)
+
+Inside the worktree:
+
+1. Confirm clean working tree: `git status --porcelain` → must be empty.
+2. Confirm on the right branch: `git rev-parse --abbrev-ref HEAD` → must equal `docs/jsdoc-<PACKAGE_SLUG>`.
+3. Baseline typecheck: `pnpm --filter <PACKAGE_NPM_NAME> typecheck`. Must pass.
+4. Baseline lint: `pnpm --filter <PACKAGE_NPM_NAME> lint`. Must pass.
+
+If any precondition fails, abort immediately and report the failure. Do not edit anything. Fixing pre-existing issues is out of scope for this campaign.
+
+## Steps (follow spec § Execution model § Stage 1)
+
+1. Read `<PACKAGE_PATH>/src/index.ts` (or `index.tsx`, whichever exists) and `<PACKAGE_PATH>/package.json#exports`. Build the Tier-1 symbol set from every name re-exported there.
+2. Enumerate in-scope files via the spec's "In scope (the where)" rule. Exclude per the spec's "Out of scope (the where)" rule — pay particular attention to the Next.js framework file list for app packages.
+3. For each in-scope file, in deterministic order (alphabetical by path):
+   - Read the file in full.
+   - For each in-scope symbol (per spec § "In scope (the what)"), classify tier using the Tier-1 rule (re-exported from barrel or `exports` map → Tier 1; else → Tier 2).
+   - Insert the JSDoc block above the symbol using `Edit` (never `Write`). Match the spec's template for the symbol's tier and shape (function / React component / server action / class / etc.).
+   - If the symbol already has a JSDoc block, leave it alone — cleanup of existing blocks is out of scope.
+4. After all files edited:
+   - Run `pnpm --filter <PACKAGE_NPM_NAME> typecheck`. Must pass. If it fails, the cause is your edits — fix or revert before continuing.
+   - Run `pnpm --filter <PACKAGE_NPM_NAME> lint --write` to absorb Biome formatting drift.
+   - Run `git diff --stat` and visually confirm: only `*.ts` / `*.tsx` files under `<PACKAGE_PATH>/src/`, no code changes other than JSDoc insertions and whitespace. If you see any non-JSDoc line change, abort and surface the diff.
+5. Generate a changeset only if `<PACKAGE_NPM_NAME>` is NOT in `.changeset/config.json#ignore`:
+   - Run `pnpm changeset` interactively-equivalent: write `.changeset/<random-slug>.md` directly with frontmatter `'<PACKAGE_NPM_NAME>': patch` and body `Backfill JSDoc on public/internal symbols.`
+6. Stage and commit:
+   ```bash
+   git add <PACKAGE_PATH>/ .changeset/
+   git commit -m "docs(<COMMIT_SCOPE>): backfill jsdoc on functions and components."
+   ```
+7. Push: `git push -u origin docs/jsdoc-<PACKAGE_SLUG>`
+8. Open PR with `gh pr create`:
+   - Title: `docs(<COMMIT_SCOPE>): backfill jsdoc on functions and components`
+   - Body template:
+     ```markdown
+     ## Summary
+     Adds JSDoc to all in-scope symbols in `<PACKAGE_PATH>` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).
+
+     ## Counts
+     - Tier-1 symbols documented: <N>
+     - Tier-2 symbols documented: <N>
+     - Files touched: <N>
+
+     ## Verification
+     - [x] `pnpm --filter <PACKAGE_NPM_NAME> typecheck` passes
+     - [x] `pnpm --filter <PACKAGE_NPM_NAME> lint` passes
+     - [x] Diff is JSDoc-only (no logic changes)
+     ```
+9. Report PR URL back to the orchestrator.
+
+## Failure handling
+
+- Context exhaustion mid-package: commit the work done so far on the branch, push, report which file you stopped at. The orchestrator will resume.
+- Typecheck breaks after your edits: identify the edit, fix or revert it. Do not commit until typecheck is green.
+- More than 20 distinct files where you're unsure how to classify a symbol: stop and ask the orchestrator before continuing.

--- a/.specs/2026-05-27-jsdoc-coverage-retrofit/plan.md
+++ b/.specs/2026-05-27-jsdoc-coverage-retrofit/plan.md
@@ -6,7 +6,7 @@
 
 **Architecture:** This plan is an orchestration plan, not a code-writing plan. The orchestrator (Claude) builds two prompt templates once (Phase 0), then dispatches per-package generator subagents in waves. Each generator runs in its own git worktree, opens one PR per package. A code-reviewer subagent reviews each PR before merge. Waves are sequential; packages within a wave run in parallel.
 
-**Tech Stack:** pnpm + turbo monorepo, Biome (lint/format), Changesets, git worktrees, `Agent` tool subagents (`general-purpose` for generators, `code-reviewer` for reviewers), `gh` CLI for PRs.
+**Tech Stack:** pnpm + turbo monorepo, Biome (lint/format), Changesets, git worktrees, `Agent` tool subagents (`general-purpose` type for both generators and reviewers; the reviewer role is conveyed entirely through the reviewer-prompt.md template), `gh` CLI for PRs.
 
 **Spec:** [`.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md`](./spec.md) — single source of truth for tier rules, templates, anti-patterns, and per-package recipe.
 
@@ -339,7 +339,7 @@ If either agent reported a precondition failure (typecheck/lint dirty on baselin
 ```json
 {
   "description": "JSDoc reviewer for errors PR",
-  "subagent_type": "code-reviewer",
+  "subagent_type": "general-purpose",
   "prompt": "<contents of .specs/2026-05-27-jsdoc-coverage-retrofit/reviewer-prompt.md, with <PR_URL>=<url from Task 7>, <PACKAGE_PATH>=packages/errors, <PACKAGE_SLUG>=errors>"
 }
 ```
@@ -475,7 +475,7 @@ Record each in working memory.
 
 ### Task 13: Dispatch reviewers for all four PRs
 
-- [ ] **Step 1: Spawn four `code-reviewer` agents in a single message**
+- [ ] **Step 1: Spawn four `general-purpose` reviewer agents in a single message (each populated with reviewer-prompt.md)**
 
 Same pattern as Task 8 Step 1, four invocations in one message.
 
@@ -534,7 +534,7 @@ Same pattern as Task 12 with five `Agent` invocations:
 
 ### Task 17: Dispatch five reviewers in parallel
 
-- [ ] **Step 1: Spawn five `code-reviewer` agents in a single message**
+- [ ] **Step 1: Spawn five `general-purpose` reviewer agents in a single message (each populated with reviewer-prompt.md)**
 
 For each PR captured in Task 16:
 
@@ -593,7 +593,7 @@ git worktree add -b docs/jsdoc-cms worktrees/jsdoc-cms master
 
 ### Task 21: Dispatch two reviewers
 
-- [ ] **Step 1: Spawn two `code-reviewer` agents in a single message**
+- [ ] **Step 1: Spawn two `general-purpose` reviewer agents in a single message (each populated with reviewer-prompt.md)**
 
 | Sub-PR             | `<PACKAGE_PATH>`     | `<PACKAGE_SLUG>` |
 |--------------------|----------------------|------------------|
@@ -651,7 +651,7 @@ Note: apps are typically in `.changeset/config.json#ignore`. The generator will 
 
 ### Task 24: Review and loop for `apps/admin`
 
-- [ ] **Step 1: Spawn `code-reviewer` agent**
+- [ ] **Step 1: Spawn `general-purpose` reviewer agent (populated with reviewer-prompt.md)**
 
 Parameters: `<PR_URL>` from Task 23 Step 4, `<PACKAGE_PATH>` = `apps/admin`, `<PACKAGE_SLUG>` = `admin`.
 
@@ -705,7 +705,7 @@ Per sub-PR:
 
 ### Task 26: Review and loop for each storefront sub-PR
 
-- [ ] **Step 1: Spawn one `code-reviewer` per sub-PR (sequential, not parallel)**
+- [ ] **Step 1: Spawn one `general-purpose` reviewer (populated with reviewer-prompt.md) per sub-PR (sequential, not parallel)**
 
 Sequential so that if blockers reveal a systemic issue, the next sub-PR's generator can be re-dispatched with that knowledge baked into its prompt.
 
@@ -762,7 +762,7 @@ Parameters: `<PACKAGE_PATH>=apps/landing`, `<PACKAGE_SLUG>=landing`, `<COMMIT_SC
 - [ ] **Step 3: Dispatch reviewer**
 
 ```
-Spawn one code-reviewer agent with reviewer-prompt.md populated:
+Spawn one general-purpose reviewer agent (with reviewer-prompt.md content as the prompt):
   <PR_URL>        = <captured in Step 2>
   <PACKAGE_PATH>  = apps/landing
   <PACKAGE_SLUG>  = landing

--- a/.specs/2026-05-27-jsdoc-coverage-retrofit/reviewer-prompt.md
+++ b/.specs/2026-05-27-jsdoc-coverage-retrofit/reviewer-prompt.md
@@ -1,0 +1,50 @@
+# JSDoc Reviewer — PR `<PR_URL>`
+
+You are the code-reviewer subagent for a JSDoc retrofit PR. Read the spec at `.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md` in full before doing anything else. It defines the tier rules and anti-patterns you must enforce.
+
+## Run parameters
+
+- PR URL: `<PR_URL>`
+- Package path: `<PACKAGE_PATH>`
+- Generator branch: `docs/jsdoc-<PACKAGE_SLUG>`
+
+## Your job
+
+Fetch the PR diff and identify blockers from the five categories below. Report findings as a structured list. If no blockers, return `LGTM`.
+
+## Blocker categories (per spec § Execution model § Stage 2)
+
+1. **Restatement.** Any JSDoc purpose line that just paraphrases the function/component name or types. The purpose must describe intent or behavior the signature does not.
+2. **Missing `@throws`.** For every modified file, run `rg -n 'throw new \w+Error' <file>` inside the file. Every distinct error class thrown must appear in the corresponding symbol's `@throws` tags. Missing tags are blockers. Spurious tags (no actual throw) are also blockers.
+3. **Tier mis-classification.** Re-derive the Tier-1 set by reading `<PACKAGE_PATH>/src/index.ts` (or `index.tsx`) and `<PACKAGE_PATH>/package.json#exports`. Any Tier-1 symbol documented at Tier 2 (no `@example`, no full `@returns`) is a blocker. Any Tier-2 symbol burdened with unnecessary `@example` is a soft blocker — flag but don't block on first iteration.
+4. **Param description that just repeats name or type.** `@param productId - The product ID.` is a blocker. `@param productId - Shopify GID for the parent product.` is fine.
+5. **Non-JSDoc code change.** Run `git diff --merge-base master -- '*.ts' '*.tsx'` and grep for any non-comment, non-whitespace change inside `<PACKAGE_PATH>/src/`. Any logic change is a blocker.
+
+## Mechanic
+
+For each modified file in the PR:
+1. `gh pr diff <PR_URL> -- <file>` to read the diff.
+2. Re-read the file in full from the PR's head ref to see context.
+3. Run the blocker checks above.
+4. Collect findings as `<file>:<line>: <category> — <one-line explanation>`.
+
+## Output format
+
+If clean: a single line `LGTM`.
+
+If blockers exist, output one Markdown section:
+
+```markdown
+## Blockers (<N>)
+
+1. `packages/foo/src/bar.ts:42` — **Restatement.** Purpose line "Adds a variant to the cart" duplicates the function name `addToCart`. Describe intent: when is this called, what side effects happen.
+2. `packages/foo/src/baz.ts:88` — **Missing `@throws`.** `throw new CartFullError(...)` at line 91 has no corresponding `@throws {CartFullError}` tag.
+…
+
+## Soft findings (<N>)
+
+(non-blocking, generator may address opportunistically)
+…
+```
+
+If reviewer flags >20 blockers, set the first line of the output to `ABORT: too noisy, recommend orchestrator narrow generator scope to a subdirectory and retry`. Then list the blockers anyway.

--- a/.specs/2026-05-27-jsdoc-coverage-retrofit/reviewer-prompt.md
+++ b/.specs/2026-05-27-jsdoc-coverage-retrofit/reviewer-prompt.md
@@ -15,10 +15,10 @@ Fetch the PR diff and identify blockers from the five categories below. Report f
 ## Blocker categories (per spec § Execution model § Stage 2)
 
 1. **Restatement.** Any JSDoc purpose line that just paraphrases the function/component name or types. The purpose must describe intent or behavior the signature does not.
-2. **Missing `@throws`.** For every modified file, run `rg -n 'throw new \w+Error' <file>` inside the file. Every distinct error class thrown must appear in the corresponding symbol's `@throws` tags. Missing tags are blockers. Spurious tags (no actual throw) are also blockers.
+2. **Missing `@throws`.** For every modified file, run `rg -n 'throw new \w+Error' <file>` inside the file (the `\w+Error` suffix matches this repo's `@nordcom/commerce-errors` naming convention where every error class name ends in `Error`). Every distinct error class thrown must appear in the corresponding symbol's `@throws` tags. Missing tags are blockers. Spurious tags (no actual throw) are also blockers.
 3. **Tier mis-classification.** Re-derive the Tier-1 set by reading `<PACKAGE_PATH>/src/index.ts` (or `index.tsx`) and `<PACKAGE_PATH>/package.json#exports`. Any Tier-1 symbol documented at Tier 2 (no `@example`, no full `@returns`) is a blocker. Any Tier-2 symbol burdened with unnecessary `@example` is a soft blocker — flag but don't block on first iteration.
 4. **Param description that just repeats name or type.** `@param productId - The product ID.` is a blocker. `@param productId - Shopify GID for the parent product.` is fine.
-5. **Non-JSDoc code change.** Run `git diff --merge-base master -- '*.ts' '*.tsx'` and grep for any non-comment, non-whitespace change inside `<PACKAGE_PATH>/src/`. Any logic change is a blocker.
+5. **Non-JSDoc code change.** From the per-file diffs collected in Mechanic step 1, scan every added or removed line inside `<PACKAGE_PATH>/src/` and confirm it is either (a) inside a JSDoc block (between `/**` and `*/`), (b) a `*`-prefixed continuation line of a JSDoc block, (c) pure whitespace, or (d) a Biome-induced trailing-comma or quote-style change. Any other diff line is a logic change and a blocker.
 
 ## Mechanic
 
@@ -43,7 +43,7 @@ If blockers exist, output one Markdown section:
 
 ## Soft findings (<N>)
 
-(non-blocking, generator may address opportunistically)
+(non-blocking. Only populate with the Tier-2 + `@example` sub-case from Blocker #3. Omit the entire section if there are none — don't write "## Soft findings (0)".)
 …
 ```
 

--- a/.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md
+++ b/.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md
@@ -199,7 +199,7 @@ Each subagent runs in its own git worktree (per `superpowers:using-git-worktrees
 
 ### Stage 2 — Reviewer subagent (per PR)
 
-Spawned with `code-reviewer` subagent type after the generator opens the PR.
+Spawned with `general-purpose` subagent type (handed the reviewer-prompt.md template) after the generator opens the PR.
 
 Reviewer flags as blockers:
 - JSDoc blocks that restate the code or types instead of describing intent.

--- a/.specs/2026-05-27-jsdoc-coverage-retrofit/wave-log.md
+++ b/.specs/2026-05-27-jsdoc-coverage-retrofit/wave-log.md
@@ -6,12 +6,12 @@ Append one section per wave as it completes. Use this as the orchestrator's runn
 
 ## Wave 1 — Foundations (errors + utils)
 
-Status: pending
-Started: —
+Status: in_progress
+Started: 2026-05-27 (session)
 Completed: —
 PRs:
-- `packages/errors`: —
-- `packages/utils`: —
+- `packages/errors`: pending generator dispatch
+- `packages/utils`: pending generator dispatch
 Calibration findings: —
 
 ## Wave 2 — Independent foundations (db, tagtree, shopify-graphql, cart/core)

--- a/.specs/2026-05-27-jsdoc-coverage-retrofit/wave-log.md
+++ b/.specs/2026-05-27-jsdoc-coverage-retrofit/wave-log.md
@@ -19,20 +19,51 @@ Calibration findings: —
 Status: pending
 Started: —
 Completed: —
-PRs: —
+PRs:
+- `packages/db`: —
+- `packages/tagtree`: —
+- `packages/shopify-graphql`: —
+- `packages/cart/core`: —
+Calibration findings: —
 
 ## Wave 3 — Dependent packages (shopify-html, marketing-common, test-mongo, cart/shopify, cart/react)
 
 Status: pending
+Started: —
+Completed: —
+PRs:
+- `packages/shopify-html`: —
+- `packages/marketing-common`: —
+- `packages/test-mongo`: —
+- `packages/cart/shopify`: —
+- `packages/cart/react`: —
+Calibration findings: —
 
 ## Wave 4 — Large packages (cart/next, cms)
 
 Status: pending
+Started: —
+Completed: —
+PRs:
+- `packages/cart/next`: —
+- `packages/cms`: —
+Calibration findings: —
 
 ## Wave 5 — Apps (admin, storefront)
 
 Status: pending
+Started: —
+Completed: —
+PRs:
+- `apps/admin`: —
+- `apps/storefront`: —
+Calibration findings: —
 
 ## Wave 6 — Final (landing)
 
 Status: pending
+Started: —
+Completed: —
+PRs:
+- `apps/landing`: —
+Calibration findings: —

--- a/.specs/2026-05-27-jsdoc-coverage-retrofit/wave-log.md
+++ b/.specs/2026-05-27-jsdoc-coverage-retrofit/wave-log.md
@@ -1,0 +1,38 @@
+# JSDoc Retrofit — Wave Log
+
+Append one section per wave as it completes. Use this as the orchestrator's running state.
+
+---
+
+## Wave 1 — Foundations (errors + utils)
+
+Status: pending
+Started: —
+Completed: —
+PRs:
+- `packages/errors`: —
+- `packages/utils`: —
+Calibration findings: —
+
+## Wave 2 — Independent foundations (db, tagtree, shopify-graphql, cart/core)
+
+Status: pending
+Started: —
+Completed: —
+PRs: —
+
+## Wave 3 — Dependent packages (shopify-html, marketing-common, test-mongo, cart/shopify, cart/react)
+
+Status: pending
+
+## Wave 4 — Large packages (cart/next, cms)
+
+Status: pending
+
+## Wave 5 — Apps (admin, storefront)
+
+Status: pending
+
+## Wave 6 — Final (landing)
+
+Status: pending

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -1,5 +1,13 @@
 import { execSync } from 'node:child_process';
 
+/**
+ * Environment metadata captured once at build time.
+ *
+ * @example
+ * ```ts
+ * const { isDev, environment, gitSHA } = resolveBuildEnv();
+ * ```
+ */
 export type BuildEnv = {
     isDev: boolean;
     environment: 'development' | 'preview' | 'production';
@@ -13,6 +21,17 @@ type InputEnv = Partial<{
     VERCEL_GIT_COMMIT_SHA: string;
 }>;
 
+/**
+ * Derives environment metadata from process variables, falling back to `git rev-parse HEAD` for the commit SHA when no variable is present.
+ *
+ * @param input - Environment variable bag. Defaults to `process.env`. Inject a plain object in tests to avoid `execSync` side-effects.
+ * @returns A {@link BuildEnv} snapshot with deployment tier, dev flag, and commit SHA.
+ * @example
+ * ```ts
+ * const env = resolveBuildEnv();
+ * console.log(env.environment); // 'development' | 'preview' | 'production'
+ * ```
+ */
 export function resolveBuildEnv(input: InputEnv = process.env as InputEnv): BuildEnv {
     const isDev = [input.NODE_ENV, input.VERCEL_ENV].includes('development');
     const environment: BuildEnv['environment'] =

--- a/packages/utils/src/hostname.ts
+++ b/packages/utils/src/hostname.ts
@@ -35,6 +35,16 @@ export type AppName = string & { readonly [AppNameBrand]: true };
 
 /** Top-level domains treated as local development. */
 export const DEV_TLDS = ['localhost', 'test'] as const;
+/**
+ * Union of TLD strings that identify a local development host.
+ *
+ * @example
+ * ```ts
+ * function isDevTld(tld: string): tld is DevTld {
+ *     return DEV_TLDS.includes(tld as DevTld);
+ * }
+ * ```
+ */
 export type DevTld = (typeof DEV_TLDS)[number];
 
 const DEV_TLD_SET: ReadonlySet<string> = new Set(DEV_TLDS);


### PR DESCRIPTION
## Summary
Adds JSDoc to all in-scope symbols in `packages/utils` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

## Counts
- Tier-1 symbols documented: 3
- Tier-2 symbols documented: 0
- Files touched: 2

## Verification
- [x] `pnpm --filter @nordcom/commerce-utils typecheck` passes
- [x] `pnpm --filter @nordcom/commerce-utils lint` passes
- [x] Diff is JSDoc-only (no logic changes)