### PR TITLE
docs(utils): address jsdoc review followup

### DIFF
--- a/packages/utils/src/hostname.ts
+++ b/packages/utils/src/hostname.ts
@@ -36,7 +36,10 @@ export type AppName = string & { readonly [AppNameBrand]: true };
 /** Top-level domains treated as local development. */
 export const DEV_TLDS = ['localhost', 'test'] as const;
 /**
- * Union of TLD strings that identify a local development host.
+ * The concrete type of `ParsedHost.tld` when `isDev` is `true`. Reach for it
+ * when annotating a parameter or variable that must hold only a dev-environment
+ * TLD value — for example, a helper that constructs dev URLs or a type guard
+ * that narrows an unknown `string` to a known dev TLD.
  *
  * @example
  * ```ts


### PR DESCRIPTION
## Summary
Addresses the 1 reviewer blocker from PR #1949 that landed unaddressed: `DevTld` purpose line was restating the type expression.

## Fix
Rewrote `DevTld` purpose to describe when/why a caller reaches for the type instead of restating `(typeof DEV_TLDS)[number]`.

## Verification
- [x] `pnpm --filter @nordcom/commerce-utils typecheck` passes
- [x] `pnpm --filter @nordcom/commerce-utils lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (no logic changes)