### PR TITLE
docs(tagtree-payload): backfill jsdoc on functions and components

### DIFF
--- a/.changeset/jsdoc-tagtree-payload.md
+++ b/.changeset/jsdoc-tagtree-payload.md
@@ -1,0 +1,5 @@
+---
+'@tagtree/payload': patch
+---
+
+Backfill JSDoc on public/internal symbols.

--- a/packages/tagtree/payload/src/hooks.ts
+++ b/packages/tagtree/payload/src/hooks.ts
@@ -9,13 +9,34 @@ type Doc = {
     _status?: 'draft' | 'published';
 };
 
+/**
+ * Extracts the tenant ID from a document, normalizing both the scalar string form and the object form Payload uses when relationship fields are expanded.
+ *
+ * @param doc - Document delivered by a Payload collection hook.
+ * @returns The tenant's ID string, or `undefined` when the document has no tenant field.
+ */
 const tenantId = (doc: Doc): string | undefined => {
     if (!doc.tenant) return undefined;
     return typeof doc.tenant === 'string' ? doc.tenant : doc.tenant.id;
 };
 
+/**
+ * Derives the cache-invalidation key for a document, preferring a stable content-addressable slug over a Shopify handle and falling back to the numeric or string ID.
+ *
+ * @param doc - Document delivered by a Payload collection hook.
+ * @returns The slug, Shopify handle, or stringified ID — in that priority order.
+ */
 const docKey = (doc: Doc): string => doc.slug ?? doc.shopifyHandle ?? String(doc.id);
 
+/**
+ * Configuration bag for `payloadHooks`, specifying which entity in the tagtree cache schema to target for invalidation and how draft-status transitions are gated.
+ *
+ * @example
+ * ```ts
+ * const opts: PayloadHooksOptions = { entity: 'products', gatePublishedDrafts: true };
+ * const hooks = payloadHooks(cache, opts);
+ * ```
+ */
 export interface PayloadHooksOptions {
     entity: string;
     /**
@@ -31,6 +52,21 @@ export interface PayloadHooksOptions {
     gatePublishedDrafts?: boolean;
 }
 
+/**
+ * Creates Payload CMS `afterChange` and `afterDelete` collection hooks that invalidate the tagtree cache whenever a document is saved or removed.
+ *
+ * @param cache - Typed tagtree `CacheInstance` holding the entity schema and invalidation logic.
+ * @param opts - Controls which entity to invalidate and whether draft-status gating is applied.
+ * @returns A `CollectionConfig['hooks']` object with `afterChange` and `afterDelete` handlers ready to merge into a collection config.
+ * @throws {Error} When `opts.entity` does not name a key declared in the cache schema.
+ * @example
+ * ```ts
+ * const productCollection: CollectionConfig = {
+ *     slug: 'products',
+ *     hooks: payloadHooks(cache, { entity: 'products', gatePublishedDrafts: true }),
+ * };
+ * ```
+ */
 export function payloadHooks<NS extends string, T extends string | { id: string }, Q, E extends EntitiesMap>(
     cache: CacheInstance<NS, T, Q, E>,
     opts: PayloadHooksOptions,


### PR DESCRIPTION
## JSDoc backfill — `@tagtree/payload`

Part of the wave-2 JSDoc coverage retrofit (spec: `.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md`).

### Symbol counts

| Tier | Count | Symbols |
|------|-------|---------|
| Tier 1 (public API) | 2 | `PayloadHooksOptions`, `payloadHooks` |
| Tier 2 (internal) | 2 | `tenantId`, `docKey` |

### Files touched

- `packages/tagtree/payload/src/hooks.ts`

### Notes

- Existing `gatePublishedDrafts` property JSDoc block is untouched.
- `Doc` type alias skipped — internal shape alias per spec.
- Closures inside `payloadHooks` (`invalidate`, `afterChange`, `afterDelete`) skipped — local helpers inside a function body per spec.
- Changeset added at patch level (`@tagtree/payload` is not in the changeset ignore glob).
- Diff is JSDoc insertions only; typecheck and lint pass.