### PR TITLE
docs(tagtree-shopify): backfill jsdoc on functions and components

### DIFF
--- a/.changeset/jsdoc-tagtree-shopify.md
+++ b/.changeset/jsdoc-tagtree-shopify.md
@@ -1,0 +1,5 @@
+---
+'@tagtree/shopify': patch
+---
+
+Backfill JSDoc on public/internal symbols.

--- a/packages/tagtree/shopify/src/hmac.ts
+++ b/packages/tagtree/shopify/src/hmac.ts
@@ -1,5 +1,22 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
+/**
+ * Verifies a Shopify webhook HMAC signature using a constant-time byte comparison to guard against timing attacks.
+ *
+ * @param rawBody - Raw, unmodified request body string; must be read before any JSON parsing or transformation.
+ * @param headerHmac - The `X-Shopify-Hmac-Sha256` header value from the incoming request; `null` causes immediate rejection without computing a digest.
+ * @param secret - The Shopify webhook shared secret for the app installation, used as the SHA-256 HMAC key.
+ * @returns `true` when the computed digest matches the header value; `false` when the header is absent, the byte lengths differ, or the digest does not match.
+ * @example
+ * ```ts
+ * const valid = verifyShopifyHmac(
+ *     rawBody,
+ *     request.headers.get('x-shopify-hmac-sha256'),
+ *     process.env.SHOPIFY_WEBHOOK_SECRET!,
+ * );
+ * if (!valid) return new Response('Forbidden', { status: 403 });
+ * ```
+ */
 export function verifyShopifyHmac(rawBody: string, headerHmac: string | null, secret: string): boolean {
     if (!headerHmac) return false;
     const computed = createHmac('sha256', secret).update(rawBody, 'utf8').digest('base64');

--- a/packages/tagtree/shopify/src/parser.ts
+++ b/packages/tagtree/shopify/src/parser.ts
@@ -19,6 +19,22 @@ const TOPIC_MAP: Record<string, TopicMapping> = {
     'pages/create': { entity: 'page', paramKey: 'handle', paramName: 'handle' },
 };
 
+/**
+ * Input bundle for {@link parseShopifyWebhook} that couples a tagtree `CacheSchema` to a single Shopify webhook event.
+ * Annotate the assembled payload with this type before calling `parseShopifyWebhook` to ensure the schema's namespace,
+ * tenant type, and entities map are carried through the generic chain.
+ *
+ * @example
+ * ```ts
+ * const input: ShopifyParseInput<typeof ns, string, string, typeof entities> = {
+ *     schema,
+ *     tenant: shop.domain,
+ *     topic: webhookTopic,
+ *     body: JSON.parse(rawBody) as Record<string, unknown>,
+ * };
+ * const tags = parseShopifyWebhook(input);
+ * ```
+ */
 export interface ShopifyParseInput<NS extends string, T, Q, E extends EntitiesMap> {
     schema: CacheSchema<NS, T, Q, E>;
     tenant: T;
@@ -26,6 +42,26 @@ export interface ShopifyParseInput<NS extends string, T, Q, E extends EntitiesMa
     body: Record<string, unknown>;
 }
 
+/**
+ * Translates a Shopify webhook event into the set of tagtree cache tags that must be invalidated.
+ *
+ * Looks up the webhook `topic` against a built-in map of Shopify product, collection, and page events,
+ * extracts the entity handle from the body, and delegates to `computeFanout` from `@tagtree/core`.
+ * Only emits tags for entities declared in the provided schema — it never invents tags that don't exist on the read side.
+ *
+ * @param input - Webhook event context: the tagtree cache schema, opaque tenant identifier, Shopify topic string, and parsed webhook body.
+ * @returns Array of cache tag strings to invalidate; empty when the topic is not mapped or the entity is absent from the schema.
+ * @example
+ * ```ts
+ * const tags = parseShopifyWebhook({
+ *     schema,
+ *     tenant: shop.domain,
+ *     topic: 'products/update',
+ *     body: JSON.parse(rawBody) as Record<string, unknown>,
+ * });
+ * for (const tag of tags) revalidateTag(tag);
+ * ```
+ */
 export function parseShopifyWebhook<NS extends string, T, Q, E extends EntitiesMap>(
     input: ShopifyParseInput<NS, T, Q, E>,
 ): string[] {


### PR DESCRIPTION
## Summary

Backfills JSDoc on all public API symbols in `@tagtree/shopify` as part of the wave-2 JSDoc coverage retrofit (spec: `.specs/2026-05-27-jsdoc-coverage-retrofit/`).

## Coverage

| Tier | Count | Symbols |
|------|------:|---------|
| Tier 1 (public API) | 3 | `verifyShopifyHmac`, `ShopifyParseInput`, `parseShopifyWebhook` |
| Tier 2 (internal) | 0 | — |

## Files touched

- `packages/tagtree/shopify/src/hmac.ts`
- `packages/tagtree/shopify/src/parser.ts`
- `.changeset/jsdoc-tagtree-shopify.md`

## Verification

- `pnpm exec tsc -noEmit` passes.
- `pnpm exec biome lint --write .` — no fixes applied.
- Diff contains only JSDoc block insertions; no code changes.