### PR TITLE
docs(tagtree-next): backfill jsdoc on functions and components

### DIFF
--- a/.changeset/jsdoc-tagtree-next.md
+++ b/.changeset/jsdoc-tagtree-next.md
@@ -1,0 +1,5 @@
+---
+'@tagtree/next': patch
+---
+
+Backfill JSDoc on public/internal symbols.

--- a/packages/tagtree/next/src/next-adapter.ts
+++ b/packages/tagtree/next/src/next-adapter.ts
@@ -3,6 +3,22 @@ import 'server-only';
 import type { AdapterCtx, CacheAdapter, WriteOpts } from '@tagtree/core';
 import { revalidateTag, unstable_cache } from 'next/cache';
 
+/**
+ * Creates a {@link CacheAdapter} that binds tagtree's cache lifecycle to the
+ * Next.js data cache, so consumers call `wrap` and `invalidate` without managing
+ * `unstable_cache` or `revalidateTag` directly.
+ *
+ * @returns A `CacheAdapter` whose `wrap` delegates to `unstable_cache` and whose
+ *   `invalidate` calls `revalidateTag` per tag in `'max'` mode.
+ * @example
+ * ```ts
+ * import { createCacheInstance, defineCache } from '@tagtree/core';
+ * import { nextAdapter } from '@tagtree/next';
+ *
+ * const shopifySchema = defineCache({ namespace: 'shopify', entities: {} });
+ * const cache = createCacheInstance(shopifySchema, nextAdapter());
+ * ```
+ */
 export function nextAdapter(): CacheAdapter {
     return {
         async read() {


### PR DESCRIPTION
## JSDoc retrofit — `@tagtree/next`

Part of the Wave 2 JSDoc coverage retrofit ([spec](/.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md)).

### Counts

| Tier | Symbols documented |
|------|-------------------|
| Tier 1 (public API) | 1 |
| Tier 2 (internal) | 0 |
| **Total** | **1** |

### Files touched

- `packages/tagtree/next/src/next-adapter.ts` — `nextAdapter` (Tier 1)

### Verification checklist

- [x] `pnpm --filter @tagtree/next typecheck` passes
- [x] `pnpm --filter @tagtree/next lint` passes (no fixes applied)
- [x] Diff contains JSDoc insertions only — no code changes
- [x] Changeset present at `.changeset/jsdoc-tagtree-next.md`
- [x] Branch rebased onto `origin/master`