### PR TITLE
docs(db): backfill jsdoc on functions and components

### DIFF
--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -4,9 +4,34 @@ import { MissingEnvironmentVariableError } from '@nordcom/commerce-errors';
 import type { Document } from 'mongoose';
 import mongoose from 'mongoose';
 
+/**
+ * String `id` virtual that Mongoose exposes on every document. All document types in this package
+ * extend `BaseDocument`, which includes this field, so callers can always read `doc.id` as a string.
+ *
+ * @example
+ * ```ts
+ * import type { DocumentExtras } from '@nordcom/commerce-db';
+ * function getId(doc: DocumentExtras): string {
+ *     return doc.id;
+ * }
+ * ```
+ */
 export type DocumentExtras = {
     id: string;
 };
+/**
+ * Timestamp fields Mongoose automatically manages when a schema is created with `timestamps: true`.
+ * Every schema in this package sets that option, so all document types carry these fields.
+ * Exposing them here lets `Service.create` strip them via `Omit<DocType, keyof BaseDocument>`.
+ *
+ * @example
+ * ```ts
+ * import type { BaseTimestamps } from '@nordcom/commerce-db';
+ * function ageMs(doc: BaseTimestamps): number {
+ *     return Date.now() - doc.createdAt.getTime();
+ * }
+ * ```
+ */
 // All schemas in this package set `timestamps: true`, so every document has
 // `createdAt`/`updatedAt`. Including them here lets `Service.create` strip
 // them from its input via `Omit<DocType, keyof BaseDocument>`.
@@ -14,6 +39,20 @@ export type BaseTimestamps = {
     createdAt: Date;
     updatedAt: Date;
 };
+/**
+ * Baseline type for every document in this package. Combines the Mongoose `Document` interface
+ * with the string `id` virtual and the managed `createdAt`/`updatedAt` fields. All model-specific
+ * types extend this via intersection rather than inherit it, so they remain compatible with plain
+ * objects returned by `.lean()`.
+ *
+ * @example
+ * ```ts
+ * import type { BaseDocument } from '@nordcom/commerce-db';
+ * function label(doc: BaseDocument): string {
+ *     return `${doc.id} (updated ${doc.updatedAt.toISOString()})`;
+ * }
+ * ```
+ */
 export type BaseDocument = Omit<Document, keyof DocumentExtras> & DocumentExtras & BaseTimestamps;
 
 const uri = process.env.MONGODB_URI as string;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,8 +2,50 @@ export * from './db';
 export * from './models';
 export * from './services';
 
+/**
+ * Converts every key of `T` to optional and nullable. Use to type partial update inputs where any
+ * field may be omitted or explicitly cleared to `null`.
+ *
+ * @example
+ * ```ts
+ * import type { Optional, ShopBase } from '@nordcom/commerce-db';
+ * async function patchShop(id: string, patch: Optional<ShopBase>) { /* ... *\/ }
+ * ```
+ */
 export type Optional<T extends { [key: string]: unknown }> = { [K in keyof T]?: Nullable<T[K]> };
+/**
+ * Adds `null` to a type to represent an explicitly absent value, distinct from `undefined` which
+ * TypeScript uses for optional properties. Use when a field can be cleared to a known empty state.
+ *
+ * @example
+ * ```ts
+ * import type { Nullable } from '@nordcom/commerce-db';
+ * const avatar: Nullable<string> = user.avatar ?? null;
+ * ```
+ */
 export type Nullable<T> = T | null;
+/**
+ * Marks an entity as having a URL-safe `handle` slug. Types that satisfy this contract can be
+ * passed to slug-based lookup and routing utilities.
+ *
+ * @example
+ * ```ts
+ * import type { Identifiable } from '@nordcom/commerce-db';
+ * function slugPath(entity: Identifiable): string {
+ *     return `/${entity.handle}/`;
+ * }
+ * ```
+ */
 export type Identifiable = { handle: string };
 
+/**
+ * Union of pagination shapes accepted by service query methods. Callers may pass either a plain
+ * `limit` cap or a forward/backward cursor pair (`first`/`last`) — both are valid at the call site.
+ *
+ * @example
+ * ```ts
+ * import type { LimitFilters } from '@nordcom/commerce-db';
+ * async function listItems(filters: LimitFilters) { /* ... *\/ }
+ * ```
+ */
 export type LimitFilters = { limit?: Nullable<number> } | { first?: Nullable<number>; last?: Nullable<number> };

--- a/packages/db/src/lib/doc-to-shape.ts
+++ b/packages/db/src/lib/doc-to-shape.ts
@@ -14,6 +14,14 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> => {
     return proto === Object.prototype || proto === null;
 };
 
+/**
+ * Recursively strips `_id` and `__v` from nested plain objects and arrays so embedded sub-documents
+ * do not carry non-serializable Mongoose `ObjectId` values.
+ *
+ * @param value - Arbitrary document value; arrays and plain objects are traversed recursively,
+ *   primitives and class instances are returned as-is.
+ * @returns The input with all nested `_id` and `__v` keys removed.
+ */
 const stripInternalsDeep = (value: unknown): unknown => {
     if (Array.isArray(value)) return value.map(stripInternalsDeep);
     if (!isPlainObject(value)) return value;
@@ -85,6 +93,20 @@ export const docToOnlineShop = (doc: Doc): OnlineShop => {
     return stripped as unknown as OnlineShop;
 };
 
+/**
+ * Projects a Mongoose lean review document onto the public `ReviewBase` shape by stripping
+ * Mongo internals (`_id`, `__v`).
+ *
+ * @param doc - Raw lean document from `ReviewModel.find().lean()`.
+ * @returns The review document as `ReviewBase`.
+ */
 export const docToReview = (doc: Doc): ReviewBase => stripInternals(doc) as unknown as ReviewBase;
 
+/**
+ * Projects a Mongoose lean feature-flag document onto the public `FeatureFlagBase` shape by
+ * stripping Mongo internals (`_id`, `__v`).
+ *
+ * @param doc - Raw lean document from `FeatureFlagModel.find().lean()`.
+ * @returns The feature flag document as `FeatureFlagBase`.
+ */
 export const docToFeatureFlag = (doc: Doc): FeatureFlagBase => stripInternals(doc) as unknown as FeatureFlagBase;

--- a/packages/db/src/models/feature-flag.ts
+++ b/packages/db/src/models/feature-flag.ts
@@ -4,13 +4,44 @@ import { Schema } from 'mongoose';
 import type { BaseDocument } from '../db';
 import { db } from '../db';
 
+/**
+ * JSON-serializable value accepted as a feature flag `defaultValue`, targeting rule output, or
+ * option value. All flag storage uses this union to stay compatible with Mongo's `Mixed` type.
+ *
+ * @example
+ * ```ts
+ * import type { JsonValue } from '@nordcom/commerce-db';
+ * const defaultValue: JsonValue = false;
+ * ```
+ */
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
+/**
+ * One selectable option in a feature flag's `options` list. Pairs a human-readable label with a
+ * JSON-safe value to support enum-style flags in the admin UI.
+ *
+ * @example
+ * ```ts
+ * import type { FeatureFlagOption } from '@nordcom/commerce-db';
+ * const opt: FeatureFlagOption = { label: 'Blue', value: 'blue' };
+ * ```
+ */
 export interface FeatureFlagOption {
     label: string;
     value: JsonValue;
 }
 
+/**
+ * One rule in a feature flag's targeting configuration. `rule` names the evaluator registered in
+ * the platform, `params` supplies its inputs, and `value` is the override returned when the rule
+ * matches the requesting context.
+ *
+ * @example
+ * ```ts
+ * import type { TargetingRule } from '@nordcom/commerce-db';
+ * const rule: TargetingRule = { rule: 'shopDomain', params: { domain: 'acme.com' }, value: true };
+ * ```
+ */
 export interface TargetingRule {
     rule: string;
     params: Record<string, JsonValue>;
@@ -51,6 +82,19 @@ FeatureFlagSchema.index({ key: 1 }, { unique: true });
 
 type InferredFeatureFlag = InferSchemaType<typeof FeatureFlagSchema>;
 
+/**
+ * Resolved document shape for a feature flag record. Combines `BaseDocument` (id, timestamps) with
+ * the schema fields, replacing inferred sub-document types with the explicit `TargetingRule` and
+ * `FeatureFlagOption` shapes. Use this type when reading flag documents from `FeatureFlagService`.
+ *
+ * @example
+ * ```ts
+ * import type { FeatureFlagBase } from '@nordcom/commerce-db';
+ * function isEnabled(flag: FeatureFlagBase): boolean {
+ *     return flag.defaultValue === true;
+ * }
+ * ```
+ */
 export type FeatureFlagBase = BaseDocument &
     Omit<InferredFeatureFlag, 'targeting' | 'options'> & {
         targeting: TargetingRule[];

--- a/packages/db/src/models/identity.ts
+++ b/packages/db/src/models/identity.ts
@@ -32,6 +32,18 @@ export const IdentitySchema = new Schema(
     },
 );
 
+/**
+ * Document shape for an OAuth provider link attached to a user. Stores the provider name, the
+ * provider-scoped identity ID, optional token fields, and the token expiry date.
+ *
+ * @example
+ * ```ts
+ * import type { IdentityBase } from '@nordcom/commerce-db';
+ * function isExpired(identity: IdentityBase): boolean {
+ *     return identity.expiresAt != null && identity.expiresAt < new Date();
+ * }
+ * ```
+ */
 export type IdentityBase = BaseDocument & InferSchemaType<typeof IdentitySchema>;
 // `identity` alone is not unique across providers — GitHub user `42` and a
 // future Google user `42` would collide on the single-field index. Lookups

--- a/packages/db/src/models/review.ts
+++ b/packages/db/src/models/review.ts
@@ -18,6 +18,18 @@ export const ReviewSchema = new Schema(
     },
 );
 
+/**
+ * Document shape for a shop review. Exposes `shop` as the full `ShopBase` rather than Mongoose's
+ * inferred embedded sub-document type, so callers can read shop fields directly from the review.
+ *
+ * @example
+ * ```ts
+ * import type { ReviewBase } from '@nordcom/commerce-db';
+ * function reviewShopName(review: ReviewBase): string {
+ *     return review.shop.name;
+ * }
+ * ```
+ */
 // `shop` infers as the embedded sub-document shape; expose the public `ShopBase` instead.
 export type ReviewBase = BaseDocument & Omit<InferSchemaType<typeof ReviewSchema>, 'shop'> & { shop: ShopBase };
 

--- a/packages/db/src/models/session.ts
+++ b/packages/db/src/models/session.ts
@@ -26,6 +26,19 @@ export const SessionSchema = new Schema(
     },
 );
 
+/**
+ * Document shape for an authenticated session. Pairs a bearer token with an expiry date and a
+ * reference to the owning user. The `user` field is always the populated `UserBase` shape; the
+ * underlying ObjectId reference is hidden by this type.
+ *
+ * @example
+ * ```ts
+ * import type { SessionBase } from '@nordcom/commerce-db';
+ * function isActive(session: SessionBase): boolean {
+ *     return session.expiresAt > new Date();
+ * }
+ * ```
+ */
 // `user` is stored as ObjectId on disk; consumers expect the populated `UserBase`.
 export type SessionBase = BaseDocument & Omit<InferSchemaType<typeof SessionSchema>, 'user'> & { user: UserBase };
 

--- a/packages/db/src/models/shop.ts
+++ b/packages/db/src/models/shop.ts
@@ -7,6 +7,16 @@ import type { FeatureFlagBase } from './feature-flag';
 import type { UserBase } from './user';
 
 // TODO: Remove this.
+/**
+ * Legacy header theme configuration superseded by the `design` property on `ShopBase`. Retained
+ * until existing theme-reading callsites are migrated to `ShopBase.design`.
+ *
+ * @example
+ * ```ts
+ * import type { ShopTheme } from '@nordcom/commerce-db';
+ * const theme: ShopTheme = { header: { theme: 'primary', themeVariant: 'default' } };
+ * ```
+ */
 export type ShopTheme = {
     header: {
         theme: 'primary' | 'secondary';
@@ -14,6 +24,19 @@ export type ShopTheme = {
     };
 };
 
+/**
+ * Auth and connection configuration for the Shopify commerce integration. Identifies the
+ * storefront via `domain` and `storefrontId`, carries the Storefront API credentials, and
+ * optionally includes the Customer Account API settings required for authenticated storefronts.
+ *
+ * @example
+ * ```ts
+ * import type { ShopifyCommerceProvider } from '@nordcom/commerce-db';
+ * function getPublicToken(cp: ShopifyCommerceProvider): string {
+ *     return cp.authentication.publicToken;
+ * }
+ * ```
+ */
 export type ShopifyCommerceProvider = {
     type: 'shopify';
     authentication: {
@@ -31,15 +54,63 @@ export type ShopifyCommerceProvider = {
     domain: string;
     id: string;
 };
+/**
+ * Auth configuration shape for the Stripe commerce integration. Currently a placeholder — the
+ * `authentication` object will gain Stripe-specific fields as that integration matures.
+ *
+ * @example
+ * ```ts
+ * import type { StripeCommerceProvider } from '@nordcom/commerce-db';
+ * const stripe: StripeCommerceProvider = { type: 'stripe', authentication: {} };
+ * ```
+ */
 export type StripeCommerceProvider = {
     type: 'stripe';
     authentication: {};
 };
+/**
+ * Discriminated union of all supported commerce provider configurations. Narrow by
+ * `commerceProvider.type` to access provider-specific credential fields.
+ *
+ * @example
+ * ```ts
+ * import type { CommerceProvider } from '@nordcom/commerce-db';
+ * function getStorefrontToken(cp: CommerceProvider): string | undefined {
+ *     return cp.type === 'shopify' ? cp.authentication.publicToken : undefined;
+ * }
+ * ```
+ */
 export type CommerceProvider = ShopifyCommerceProvider | StripeCommerceProvider;
 
 export const CommerceProviders = ['shopify', 'stripe'] as const satisfies CommerceProvider['type'][];
+/**
+ * Literal union of valid commerce provider type strings, constrained to the same set as the
+ * runtime `CommerceProviders` array. Use to type `commerceProvider.type` parameters in service
+ * methods and admin forms without hardcoding string literals.
+ *
+ * @example
+ * ```ts
+ * import type { CommerceProviders } from '@nordcom/commerce-db';
+ * function isSupported(type: string): type is CommerceProviders {
+ *     return (CommerceProviders as readonly string[]).includes(type);
+ * }
+ * ```
+ */
 export type CommerceProviders = (typeof CommerceProviders)[number];
 
+/**
+ * Embedded reference in a shop's `featureFlags` array. When loaded without population, `flag` is
+ * a Mongoose `ObjectId`; after `Shop.findByDomain({ populate: ['featureFlags.flag'] })` it is the
+ * full `FeatureFlagBase` document. Narrow with `typeof flag === 'object' && 'key' in flag`.
+ *
+ * @example
+ * ```ts
+ * import type { FeatureFlagRef } from '@nordcom/commerce-db';
+ * function isFlagPopulated(ref: FeatureFlagRef): boolean {
+ *     return typeof ref.flag === 'object' && 'key' in ref.flag;
+ * }
+ * ```
+ */
 // `flag` is stored as an ObjectId in MongoDB. After `populate('featureFlags.flag')`
 // (see `Shop.findByDomain({ populate })`), the field is the full FeatureFlag
 // document. Consumers receive whichever shape the query produced; runtime code
@@ -48,6 +119,20 @@ export interface FeatureFlagRef {
     flag: import('mongoose').Types.ObjectId | FeatureFlagBase;
 }
 
+/**
+ * Raw document shape for a multi-tenant shop record as stored in MongoDB. Extends `BaseDocument`
+ * with all tenant-specific configuration fields including domain routing, commerce provider
+ * credentials, design tokens, and feature flags. Use `OnlineShop` for client-facing work since it
+ * strips the Mongoose document overhead and masks credential fields.
+ *
+ * @example
+ * ```ts
+ * import type { ShopBase } from '@nordcom/commerce-db';
+ * function getDefaultLocale(shop: ShopBase): string {
+ *     return shop.i18n?.defaultLocale ?? 'en-US';
+ * }
+ * ```
+ */
 export interface ShopBase extends BaseDocument {
     name: string;
     description?: string;
@@ -116,6 +201,20 @@ export interface ShopBase extends BaseDocument {
     featureFlags?: FeatureFlagRef[];
 }
 
+/**
+ * Client-safe shop shape derived from `ShopBase` with Mongoose document methods stripped.
+ * Returned by all `ShopService` read methods; safe to pass to Client Components or server actions.
+ * Credential fields (`authentication.token`, `customers.clientSecret`) are masked by
+ * `docToOnlineShop` unless `sensitiveData: true` is passed to `ShopService.findByDomain`.
+ *
+ * @example
+ * ```ts
+ * import type { OnlineShop } from '@nordcom/commerce-db';
+ * function shopDomain(shop: OnlineShop): string {
+ *     return shop.domain;
+ * }
+ * ```
+ */
 export type OnlineShop = Omit<ShopBase, keyof Omit<Document, keyof DocumentExtras> | 'collaborators' | 'schema'> & {
     collaborators?: ShopBase['collaborators'];
 };

--- a/packages/db/src/models/user.ts
+++ b/packages/db/src/models/user.ts
@@ -52,6 +52,19 @@ export const UserSchema = new Schema(
 
 type InferredUser = InferSchemaType<typeof UserSchema>;
 
+/**
+ * Document shape for a platform user. Carries an embedded list of OAuth identities and satisfies
+ * the NextAuth adapter contract — specifically the optional `avatar` and nullable `emailVerified`
+ * fields that the adapter reads after `User.create` and `User.find`.
+ *
+ * @example
+ * ```ts
+ * import type { UserBase } from '@nordcom/commerce-db';
+ * function displayName(user: UserBase): string {
+ *     return user.name;
+ * }
+ * ```
+ */
 // `avatar` and `emailVerified` use `default: null` in the schema; the public
 // API exposes them as optional/nullable to match the NextAuth adapter contract.
 export type UserBase = BaseDocument &

--- a/packages/db/src/services/feature-flag.ts
+++ b/packages/db/src/services/feature-flag.ts
@@ -10,11 +10,31 @@ import { FeatureFlagModel } from '../models';
  * unchanged.
  */
 export class FeatureFlagService {
+    /**
+     * Retrieves a single feature flag by its unique key.
+     *
+     * @param key - The flag's unique string key, as set in the admin interface.
+     * @returns The flag document, or `null` when no flag with that key exists.
+     * @example
+     * ```ts
+     * const darkMode = await FeatureFlag.findByKey('dark-mode');
+     * if (darkMode) { /* evaluate flag *\/ }
+     * ```
+     */
     public async findByKey(key: string): Promise<FeatureFlagBase | null> {
         const doc = await FeatureFlagModel.findOne({ key }).lean<FeatureFlagBase>().exec();
         return doc ? docToFeatureFlag(doc as unknown as Record<string, unknown>) : null;
     }
 
+    /**
+     * Returns all feature flags, suitable for bulk evaluation or the admin flag index.
+     *
+     * @returns Array of all persisted flag documents; empty when none exist.
+     * @example
+     * ```ts
+     * const flags = await FeatureFlag.findAll();
+     * ```
+     */
     public async findAll(): Promise<FeatureFlagBase[]> {
         const docs = await FeatureFlagModel.find({}).lean<FeatureFlagBase[]>().exec();
         return docs.map((d) => docToFeatureFlag(d as unknown as Record<string, unknown>));

--- a/packages/db/src/services/review.ts
+++ b/packages/db/src/services/review.ts
@@ -13,6 +13,17 @@ type FindOptions = {
  * prior Payload-backed service so callsites are unchanged.
  */
 export class ReviewService {
+    /**
+     * Returns reviews submitted for a specific shop, optionally capped at a maximum count.
+     *
+     * @param shopId - The MongoDB `_id` string of the shop whose reviews to load.
+     * @param options.count - Maximum number of reviews to return; omit for all.
+     * @returns Reviews belonging to the shop, stripped of Mongo internals.
+     * @example
+     * ```ts
+     * const latest = await Review.findByShop(shop.id, { count: 5 });
+     * ```
+     */
     public async findByShop(shopId: string, { count }: FindOptions = {}): Promise<ReviewBase[]> {
         let query = ReviewModel.find({ shop: shopId });
         if (count) query = query.limit(count);
@@ -20,6 +31,16 @@ export class ReviewService {
         return docs.map((d) => docToReview(d as unknown as Record<string, unknown>));
     }
 
+    /**
+     * Returns all reviews, with an optional tenant filter for cross-shop admin views.
+     *
+     * @param options.tenant - When set, restricts results to reviews that match that tenant value.
+     * @returns All review documents passing the filter, stripped of Mongo internals.
+     * @example
+     * ```ts
+     * const all = await Review.findAll();
+     * ```
+     */
     public async findAll({ tenant }: { tenant?: string } = {}): Promise<ReviewBase[]> {
         const filter = tenant ? { tenant } : {};
         const docs = await ReviewModel.find(filter).lean<ReviewBase[]>().exec();

--- a/packages/db/src/services/service.ts
+++ b/packages/db/src/services/service.ts
@@ -31,16 +31,42 @@ interface BaseFilterableQuery<I> {
     projection?: ProjectionType<I> | undefined;
 }
 
+/**
+ * Generic Mongoose-backed CRUD base for all document services in this package. Subclasses
+ * specialize it with a concrete model type and may override individual methods to add
+ * domain-specific validation, projection, or shape conversion.
+ */
 export class Service<DocType extends BaseDocument, M extends typeof Model<DocType>> {
     private readonly modelName: string;
+    /**
+     * Returns the Mongoose model instance, looked up by name from the active connection to pick
+     * up hot-reloaded or re-registered models in development.
+     *
+     * @returns The Mongoose model for `DocType`.
+     */
     get model(): M {
         return db.models[this.modelName] as M;
     }
 
+    /**
+     * Stores the model name rather than the model instance so that hot-reloads during development
+     * do not leave this service holding a stale model reference.
+     *
+     * @param model - The Mongoose model constructor this service operates on; only its
+     *   `modelName` is retained.
+     */
     public constructor(model: M) {
         this.modelName = model.modelName;
     }
 
+    /**
+     * Persists a new document. `BaseDocument` fields (id, timestamps) are excluded from the input
+     * type because Mongoose generates them automatically on insert.
+     *
+     * @param input - Document fields excluding those managed by the base schema (`id`, `createdAt`,
+     *   `updatedAt`).
+     * @returns The persisted document including the generated `id` and timestamps.
+     */
     public async create(input: Omit<DocType, keyof BaseDocument>): Promise<DocType> {
         // `Model.create()` already persists the document; the previous code
         // chained `.then((doc) => doc.save())` which re-saved a clean doc and
@@ -74,6 +100,18 @@ export class Service<DocType extends BaseDocument, M extends typeof Model<DocTyp
         return () => req as Q;
     }
 
+    /**
+     * Executes a Mongoose query with optional pagination and field projection. Passing `id` or
+     * `count: 1` activates the single-document overload; any other combination returns an array.
+     *
+     * @param args.id - When set, queries by `_id` and returns one document.
+     * @param args.count - Limits the number of returned documents; `1` activates the
+     *   single-document overload.
+     * @param args.filter - Mongoose query filter applied before the limit.
+     * @param args.projection - Fields to include or exclude from returned documents.
+     * @returns A single `DocType` when `id` or `count: 1`; otherwise `DocType[]`.
+     * @throws {NotFoundError} When `id` or `count: 1` is set and no matching document exists.
+     */
     public async find(args: MergeTypes<[BaseQuery, BaseFilterableQuery<DocType>, ReturnsOneQuery]>): Promise<DocType>;
     public async find(args: MergeTypes<[BaseQuery, BaseFilterableQuery<DocType>]>): Promise<DocType[]>;
     public async find(args: MergeTypes<[BaseQuery, BaseFilterableQuery<DocType>]>): Promise<DocType | DocType[]> {
@@ -116,6 +154,14 @@ export class Service<DocType extends BaseDocument, M extends typeof Model<DocTyp
         return res as DocType[];
     }
 
+    /**
+     * Finds a document by its MongoDB `_id`, returning `null` when absent rather than throwing.
+     *
+     * @param id - MongoDB `_id` string.
+     * @param projection - Fields to include or exclude from the returned document.
+     * @param options - Mongoose query options (e.g. `lean`, `session`).
+     * @returns The matching document, or `null` when no document with that `_id` exists.
+     */
     public async findById(
         id: string,
         projection?: ProjectionType<DocType> | null,
@@ -131,6 +177,14 @@ export class Service<DocType extends BaseDocument, M extends typeof Model<DocTyp
         return res ?? null;
     }
 
+    /**
+     * Atomically finds and updates one document matching the filter.
+     *
+     * @param filter - Mongoose query filter that selects the target document.
+     * @param update - Update expression applied to the matched document.
+     * @param options - Mongoose update options; defaults to `{ lean: true }`.
+     * @returns The updated document, or `null` when no document matched the filter.
+     */
     public async findOneAndUpdate(
         filter: QueryFilter<DocType>,
         update?: UpdateQuery<DocType>,

--- a/packages/db/src/services/shop.ts
+++ b/packages/db/src/services/shop.ts
@@ -5,6 +5,18 @@ import type { OnlineShop, ShopBase } from '../models';
 import { ShopModel } from '../models';
 import { Service } from './service';
 
+/**
+ * Controls how `ShopService.findByDomain` fetches and returns the document. Allows callers to
+ * skip shape conversion, include sensitive credentials, or populate feature-flag references in a
+ * single call.
+ *
+ * @example
+ * ```ts
+ * import type { FindOptions } from '@nordcom/commerce-db';
+ * const opts: FindOptions = { populate: ['featureFlags.flag'] };
+ * const shop = await Shop.findByDomain('acme.com', opts);
+ * ```
+ */
 export type FindOptions = {
     /** Whether to convert the result to a normal object or keep it as the raw Mongoose lean doc. */
     convert?: boolean;
@@ -13,11 +25,43 @@ export type FindOptions = {
     populate?: string[];
 };
 
+/**
+ * CRUD service for the `shops` MongoDB collection. Extends the generic `Service` base with
+ * shop-specific queries, domain-based lookup, and the credential-masking pipeline that strips
+ * sensitive fields before returning the public `OnlineShop` shape.
+ *
+ * @example
+ * ```ts
+ * import { Shop } from '@nordcom/commerce-db';
+ * const shop = await Shop.findByDomain('acme.myshopify.com');
+ * ```
+ */
 export class ShopService extends Service<ShopBase, typeof ShopModel> {
+    /**
+     * Binds the service to the `ShopModel` Mongoose model.
+     *
+     * @example
+     * ```ts
+     * import { ShopService } from '@nordcom/commerce-db';
+     * const service = new ShopService();
+     * ```
+     */
     public constructor() {
         super(ShopModel);
     }
 
+    /**
+     * Resolves a shop by its MongoDB `_id`, stripping Mongo internals and returning the public
+     * `OnlineShop` shape. Overrides the base `findById` to always throw rather than return `null`.
+     *
+     * @param id - MongoDB `_id` of the shop to load.
+     * @returns The shop as `OnlineShop`.
+     * @throws {UnknownShopIdError} When no shop with that `_id` exists.
+     * @example
+     * ```ts
+     * const shop = await Shop.findById(shopId);
+     * ```
+     */
     // Override the Mongoose-based base method with a typed implementation. The
     // base returns `Promise<ShopBase | null>`; here we narrow to
     // `Promise<OnlineShop>` (always resolves or throws). Cast through `never`
@@ -30,11 +74,44 @@ export class ShopService extends Service<ShopBase, typeof ShopModel> {
         })() as Promise<OnlineShop> & Promise<ShopBase | null>;
     }
 
+    /**
+     * Returns all shops where the given user is listed as a collaborator.
+     *
+     * @param options.collaboratorId - The user's MongoDB `_id` string matched against
+     *   `collaborators.user` in the shop document.
+     * @returns Shops the collaborator has access to; empty array when none.
+     * @example
+     * ```ts
+     * const myShops = await Shop.findByCollaborator({ collaboratorId: user.id });
+     * ```
+     */
     public async findByCollaborator({ collaboratorId }: { collaboratorId: string }): Promise<OnlineShop[]> {
         const docs = await ShopModel.find({ 'collaborators.user': collaboratorId }).lean<ShopBase[]>().exec();
         return docs.map((d) => docToOnlineShop(d as unknown as Record<string, unknown>)).filter((d) => d);
     }
 
+    /**
+     * Resolves a shop by its primary domain or any listed alternative domain. By default strips
+     * Mongo internals and masks credential fields before returning.
+     *
+     * @param domain - Fully-qualified hostname to look up (no scheme, no port).
+     * @param options.convert - When `false`, returns the raw lean doc as `ShopBase`. Defaults to
+     *   `true`.
+     * @param options.sensitiveData - When `true`, skips credential masking so
+     *   `commerceProvider.authentication.token` is present. Defaults to `false`.
+     * @param options.populate - Mongoose population paths to resolve (e.g. `featureFlags.flag`).
+     * @returns The matched shop as `OnlineShop` by default, or `ShopBase` when `convert: false`.
+     * @throws {InvalidShopDomainError} When `domain` is empty or falsy.
+     * @throws {UnknownShopDomainError} When no shop claims the given domain or any of its
+     *   alternatives.
+     * @example
+     * ```ts
+     * const shop = await Shop.findByDomain('acme.myshopify.com');
+     * const shopWithFlags = await Shop.findByDomain('acme.myshopify.com', {
+     *     populate: ['featureFlags.flag'],
+     * });
+     * ```
+     */
     public async findByDomain(domain: string, options?: FindOptions): Promise<OnlineShop | ShopBase>;
     public async findByDomain(
         domain: string,
@@ -58,6 +135,16 @@ export class ShopService extends Service<ShopBase, typeof ShopModel> {
         return docToOnlineShop(doc as unknown as Record<string, unknown>);
     }
 
+    /**
+     * Returns all shops in the platform. Query errors are caught and logged; callers receive an
+     * empty array on failure rather than a thrown exception.
+     *
+     * @returns All shops as `OnlineShop[]`; returns `[]` when the query fails.
+     * @example
+     * ```ts
+     * const shops = await Shop.findAll();
+     * ```
+     */
     public async findAll(): Promise<OnlineShop[]> {
         try {
             const docs = await ShopModel.find({}).lean<ShopBase[]>().exec();


### PR DESCRIPTION
## Summary
Adds JSDoc to all in-scope symbols in `packages/db` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

## Counts
- Tier-1 symbols documented: 34
- Tier-2 symbols documented: 10
- Files touched: 13

## Verification
- [x] `pnpm --filter @nordcom/commerce-db typecheck` passes
- [x] `pnpm --filter @nordcom/commerce-db lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (no logic changes)