### PR TITLE
docs(tagtree-core): backfill jsdoc on functions and components

### DIFF
--- a/.changeset/jsdoc-tagtree-core.md
+++ b/.changeset/jsdoc-tagtree-core.md
@@ -1,0 +1,5 @@
+---
+'@tagtree/core': patch
+---
+
+Backfill JSDoc on public/internal symbols.

--- a/packages/tagtree/core/src/adapter.ts
+++ b/packages/tagtree/core/src/adapter.ts
@@ -1,5 +1,20 @@
 import type { CacheSchemaShape, EntitiesMap } from './schema';
 
+/**
+ * Minimal structured-log interface that cache adapters and the instance internals use to report
+ * events without pulling in a concrete logging dependency.
+ *
+ * @example
+ * ```ts
+ * const myLogger: ILogger = {
+ *     debug: (msg) => process.stdout.write(`[debug] ${msg}\n`),
+ *     info:  (msg) => process.stdout.write(`[info]  ${msg}\n`),
+ *     warn:  (msg) => process.stderr.write(`[warn]  ${msg}\n`),
+ *     error: (msg) => process.stderr.write(`[error] ${msg}\n`),
+ * };
+ * const cache = createCacheInstance(mySchema, myAdapter, { logger: myLogger });
+ * ```
+ */
 export interface ILogger {
     debug: (msg: string, meta?: Record<string, unknown>) => void;
     info: (msg: string, meta?: Record<string, unknown>) => void;
@@ -7,22 +22,62 @@ export interface ILogger {
     error: (msg: string, meta?: Record<string, unknown>) => void;
 }
 
+/**
+ * Runtime context passed to every adapter operation, carrying the schema definition and a logger
+ * so adapters can emit structured diagnostics tied to the call site.
+ *
+ * @example
+ * ```ts
+ * const ctx: AdapterCtx = {
+ *     schema: myCache.schema,
+ *     logger: consoleLogger,
+ * };
+ * await myAdapter.read('some-key', ctx);
+ * ```
+ */
 export interface AdapterCtx<S extends CacheSchemaShape = CacheSchemaShape<string, unknown, unknown, EntitiesMap>> {
+    /** The resolved cache schema shape; adapters may inspect `schema.namespace` for scoped logging. */
     schema: S;
+    /** Logger instance for emitting diagnostics from within adapter operations. */
     logger: ILogger;
+    /** Opaque per-request value that adapter implementations may use to correlate operations across a single request lifecycle. */
     requestScope?: unknown;
 }
 
+/**
+ * Options that govern how a cache entry is stored; controls TTL expiry, stale-while-revalidate
+ * behavior, and a staleness-guard timestamp that prevents a racing webhook from being overwritten
+ * by a fetch that started before the invalidation arrived.
+ *
+ * @example
+ * ```ts
+ * await instance.write(key, data, { ttl: 300, swr: true });
+ * ```
+ */
 export interface WriteOpts {
+    /** Entry lifetime in seconds; omit for indefinite storage. */
     ttl?: number;
+    /** When `true`, the adapter may return a stale entry and revalidate in the background. */
     swr?: boolean;
     // Drop the write if the tag index records an invalidation newer than this timestamp.
     // wrap() records a "fetch started at" timestamp before invoking the fetcher and
     // passes it here, so a webhook that fires invalidation while the fetcher is in
     // flight wins the race.
+    /** Reject the write if any of the entry's tags were invalidated after this epoch timestamp. */
     writeIfNewerThan?: number;
 }
 
+/**
+ * Contract that every cache backend must implement to integrate with tagtree's tag-aware
+ * invalidation model. Adapters are responsible for storage, tag-index maintenance, and
+ * optional features like response decoration or native wrap delegation.
+ *
+ * @example
+ * ```ts
+ * const adapter: CacheAdapter = memoryAdapter({ maxEntries: 500 });
+ * const cache = createCacheInstance(mySchema, adapter);
+ * ```
+ */
 export interface CacheAdapter {
     read(key: string, ctx: AdapterCtx): Promise<{ value: unknown; tags: string[] } | undefined>;
     write(key: string, value: unknown, tags: string[], opts: WriteOpts, ctx: AdapterCtx): Promise<void>;
@@ -34,6 +89,15 @@ export interface CacheAdapter {
     init?(): Promise<void>;
 }
 
+/**
+ * Ready-made `ILogger` implementation that prefixes all messages with `[tagtree]` and forwards to
+ * the native `console` methods; suitable for development and low-volume production use.
+ *
+ * @example
+ * ```ts
+ * const cache = createCacheInstance(mySchema, myAdapter, { logger: consoleLogger });
+ * ```
+ */
 export const consoleLogger: ILogger = {
     debug: (msg, meta) => console.debug(`[tagtree] ${msg}`, meta ?? ''),
     info: (msg, meta) => console.info(`[tagtree] ${msg}`, meta ?? ''),

--- a/packages/tagtree/core/src/cache.ts
+++ b/packages/tagtree/core/src/cache.ts
@@ -4,12 +4,40 @@ import { buildInvalidateNamespace, type InvalidateNamespace } from './invalidate
 import { buildKeyFactory, type CacheKey, type KeyFactory } from './keys';
 import type { CacheSchema, CacheSchemaShape, EntitiesMap } from './schema';
 
+/**
+ * Per-call options for `CacheInstance.wrap`, extending basic storage controls with a staleness
+ * guard that prevents a late-arriving write from overwriting an invalidation that fired while the
+ * fetcher was in flight.
+ *
+ * @example
+ * ```ts
+ * const data = await cache.wrap(key, fetcher, { ttl: 60, stalenessGuard: true });
+ * ```
+ */
 export interface WrapOpts {
+    /** Entry lifetime in seconds; omit for indefinite storage. */
     ttl?: number;
+    /** When `true`, the adapter may serve a stale entry while revalidating. */
     swr?: boolean;
+    /**
+     * When `true`, records the fetch start time and passes it as `WriteOpts.writeIfNewerThan` so
+     * any tag invalidation that arrived while the fetcher ran causes the write to be discarded.
+     */
     stalenessGuard?: boolean;
 }
 
+/**
+ * Fully-typed runtime handle returned by `createCacheInstance`; binds a cache schema, a storage
+ * adapter, and derived key/invalidation helpers into a single callable surface.
+ *
+ * @example
+ * ```ts
+ * const cache = createCacheInstance(productSchema, memoryAdapter());
+ * const key = cache.keys.product({ tenant: shop, id: '123' });
+ * const data = await cache.wrap(key, () => fetchProduct('123'), { ttl: 300 });
+ * await cache.invalidate.product({ tenant: shop, id: '123' });
+ * ```
+ */
 export interface CacheInstance<
     NS extends string = string,
     T = unknown,
@@ -25,6 +53,21 @@ export interface CacheInstance<
     invalidateRaw(tags: string[]): Promise<void>;
 }
 
+/**
+ * Wires a `CacheSchema` definition to a storage adapter and returns a typed `CacheInstance` ready
+ * for read, write, and invalidate operations.
+ *
+ * @param cache - Schema produced by `defineCache`; supplies entity, tenant, and qualifier shapes.
+ * @param adapter - Storage backend implementing `CacheAdapter`.
+ * @param options - Optional overrides; `logger` replaces `consoleLogger` as the diagnostic sink.
+ * @returns A fully-typed `CacheInstance` bound to the schema's entity and tenant shapes.
+ * @example
+ * ```ts
+ * const productCache = createCacheInstance(productSchema, memoryAdapter(), {
+ *     logger: consoleLogger,
+ * });
+ * ```
+ */
 export function createCacheInstance<NS extends string, T, Q, E extends EntitiesMap>(
     cache: CacheSchema<NS, T, Q, E>,
     adapter: CacheAdapter,

--- a/packages/tagtree/core/src/compose.ts
+++ b/packages/tagtree/core/src/compose.ts
@@ -1,5 +1,21 @@
 import type { AdapterCtx, CacheAdapter } from './adapter';
 
+/**
+ * Chains multiple `CacheAdapter` implementations into one, reading from adapters in priority order
+ * until a hit is found and fanning writes and invalidations out to all of them. Adapter errors are
+ * caught, logged, and swallowed rather than propagated so a failing secondary never blocks a read.
+ *
+ * @param adapters - Ordered adapters; read attempts proceed left to right, stopping at the first hit.
+ * @returns A composite `CacheAdapter` that delegates every operation to all supplied backends.
+ * @example
+ * ```ts
+ * const adapter = compose(
+ *     memoryAdapter({ maxEntries: 200 }),
+ *     redisAdapter({ url: process.env.REDIS_URL }),
+ * );
+ * const cache = createCacheInstance(mySchema, adapter);
+ * ```
+ */
 export function compose(...adapters: CacheAdapter[]): CacheAdapter {
     const settle = async <R>(p: Promise<R>, label: string, ctx: AdapterCtx): Promise<R | undefined> => {
         try {

--- a/packages/tagtree/core/src/contract-tests.ts
+++ b/packages/tagtree/core/src/contract-tests.ts
@@ -8,14 +8,52 @@ const ctx: AdapterCtx = {
     logger: consoleLogger,
 };
 
+/**
+ * Configuration passed to `runAdapterContract`; declares how to create and tear down the adapter
+ * under test and which optional protocol features the adapter supports.
+ *
+ * @example
+ * ```ts
+ * runAdapterContract({
+ *     name: 'memory',
+ *     create: () => memoryAdapter(),
+ *     supportsTtl: true,
+ *     supportsStalenessGuard: true,
+ * });
+ * ```
+ */
 export interface ContractTestOptions {
+    /** Label used in the Vitest `describe` block to identify the adapter under test. */
     name: string;
+    /** Factory that returns a fresh adapter instance for each individual test case. */
     create: () => Promise<CacheAdapter> | CacheAdapter;
+    /** Optional cleanup hook called after each test to release adapter resources such as connections. */
     teardown?: (a: CacheAdapter) => Promise<void> | void;
+    /** Set to `true` if the adapter enforces TTL-based expiry; enables the TTL test suite. */
     supportsTtl?: boolean;
+    /** Set to `true` if the adapter honors `WriteOpts.writeIfNewerThan`; enables the staleness-guard suite. */
     supportsStalenessGuard?: boolean;
 }
 
+/**
+ * Registers a Vitest `describe` block that verifies an adapter implementation satisfies the
+ * `CacheAdapter` contract; call this inside each adapter package's own test suite to catch
+ * behavioral regressions without duplicating test logic.
+ *
+ * @param opts - Test configuration; controls which adapter to test and which optional cases to run.
+ * @example
+ * ```ts
+ * import { runAdapterContract } from '@tagtree/core/contract-tests';
+ * import { memoryAdapter } from '@tagtree/core';
+ *
+ * runAdapterContract({
+ *     name: 'memory',
+ *     create: () => memoryAdapter(),
+ *     supportsTtl: true,
+ *     supportsStalenessGuard: true,
+ * });
+ * ```
+ */
 export function runAdapterContract(opts: ContractTestOptions): void {
     describe(`adapter contract: ${opts.name}`, () => {
         const setup = async () => {

--- a/packages/tagtree/core/src/encode.ts
+++ b/packages/tagtree/core/src/encode.ts
@@ -1,11 +1,37 @@
 // Tag segments are joined with ".", so any literal "." in a segment must be encoded.
 // We also encode ":" because the qualifier separator uses "::". Beyond those two,
 // encodeURIComponent handles the long tail (spaces, slashes, emoji, etc.).
+
+/**
+ * Encodes a single cache-key segment so it is safe to join with `.` as a separator; escapes `.`
+ * and `:` in addition to the characters `encodeURIComponent` already handles.
+ *
+ * @param value - Raw segment value — a human-readable label or a numeric identifier.
+ * @returns The percent-encoded segment string, safe for use as a dotted-path component.
+ * @example
+ * ```ts
+ * encodeSegment('shop.example.com'); // 'shop%2Eexample%2Ecom'
+ * encodeSegment(42);                 // '42'
+ * ```
+ */
 export function encodeSegment(value: string | number): string {
     const str = typeof value === 'number' ? String(value) : value;
     return encodeURIComponent(str).replace(/\./g, '%2E').replace(/:/g, '%3A');
 }
 
+/**
+ * Combines an ordered list of raw segments into a dotted-path cache tag, encoding each segment
+ * before joining so no raw value can break the path structure.
+ *
+ * @param segments - Ordered raw segment values that together form a cache tag (e.g. namespace, tenant key, entity name).
+ * @returns A dotted-path string suitable for use as a tagtree cache tag.
+ * @throws {Error} When any segment encodes to an empty string, which would produce an ambiguous tag.
+ * @example
+ * ```ts
+ * joinSegments(['commerce', 'shop.example.com', 'product', '123']);
+ * // 'commerce.shop%2Eexample%2Ecom.product.123'
+ * ```
+ */
 export function joinSegments(segments: ReadonlyArray<string | number>): string {
     const out: string[] = [];
     for (const seg of segments) {

--- a/packages/tagtree/core/src/fanout.ts
+++ b/packages/tagtree/core/src/fanout.ts
@@ -1,12 +1,46 @@
 import { joinSegments } from './encode';
 import type { CacheSchemaShape, EntitiesMap } from './schema';
 
+/**
+ * Arguments to `computeFanout` describing which entity to expand and the optional tenant and
+ * param values that narrow the resulting tag set.
+ *
+ * @example
+ * ```ts
+ * const tags = computeFanout(mySchema.schema, {
+ *     entity: 'product',
+ *     tenant: shop,
+ *     params: { id: '123' },
+ * });
+ * ```
+ */
 export interface FanoutInput<T = unknown> {
+    /** Name of the entity declared in the schema to expand into invalidation tags. */
     entity: string;
+    /** Tenant value whose key is prepended to all tags when the schema defines a `TenantConfig`. */
     tenant?: T;
+    /** Per-entity parameter values that produce a leaf tag when all declared params are present. */
     params?: Record<string, string | number>;
 }
 
+/**
+ * Expands a single entity reference into its full set of invalidation tags, from the most-specific
+ * leaf tag down to the namespace root, following the hierarchy declared in the schema.
+ *
+ * @param schema - Resolved cache schema shape containing entity, tenant, and namespace configuration.
+ * @param input - Entity reference with optional tenant and params that narrow the expansion.
+ * @returns Ordered array of cache tags from leaf to namespace root, suitable for passing to an adapter's `invalidate` call.
+ * @throws {Error} When `input.entity` is not declared in `schema.entities`.
+ * @example
+ * ```ts
+ * const tags = computeFanout(productSchema.schema, {
+ *     entity: 'product',
+ *     tenant: shop,
+ *     params: { id: '123' },
+ * });
+ * // ['commerce.acme.product.123', 'commerce.acme.product', 'commerce.acme', 'commerce']
+ * ```
+ */
 export function computeFanout<NS extends string, T, Q, E extends EntitiesMap>(
     schema: CacheSchemaShape<NS, T, Q, E>,
     input: FanoutInput<T>,

--- a/packages/tagtree/core/src/invalidate.ts
+++ b/packages/tagtree/core/src/invalidate.ts
@@ -11,11 +11,34 @@ type EntityInvalidators<E extends EntitiesMap, T> = {
     [K in keyof E]: (arg: EntityInvalidatorArg<T, E[K]>) => Promise<void>;
 };
 
+/**
+ * Typed invalidation surface generated from a `CacheSchemaShape`; exposes a method per declared
+ * entity plus `tenant` and `all` shortcuts, so callers get autocompletion and type-checked params
+ * instead of constructing raw tag arrays by hand.
+ *
+ * @example
+ * ```ts
+ * // Invalidate a single product by ID for a specific tenant.
+ * await cache.invalidate.product({ tenant: shop, id: '123' });
+ * // Invalidate all entries for a tenant.
+ * await cache.invalidate.tenant(shop);
+ * // Purge the entire namespace.
+ * await cache.invalidate.all();
+ * ```
+ */
 export type InvalidateNamespace<T = unknown, E extends EntitiesMap = EntitiesMap> = EntityInvalidators<E, T> & {
     tenant(tenant: T): Promise<void>;
     all(): Promise<void>;
 };
 
+/**
+ * Constructs the `InvalidateNamespace` object for a schema, wiring each entity name to a
+ * fanout-then-fire handler and providing `tenant` and `all` shortcut methods.
+ *
+ * @param schema - The resolved schema shape that defines entities, tenant configuration, and namespace.
+ * @param fire - Callback that receives the computed tag array and performs the actual adapter invalidation.
+ * @returns A fully-typed `InvalidateNamespace` bound to the schema's entity names and tenant type.
+ */
 export function buildInvalidateNamespace<NS extends string, T, Q, E extends EntitiesMap>(
     schema: CacheSchemaShape<NS, T, Q, E>,
     fire: (tags: string[]) => Promise<void>,

--- a/packages/tagtree/core/src/keys.ts
+++ b/packages/tagtree/core/src/keys.ts
@@ -2,9 +2,22 @@ import { computeFanout } from './fanout';
 import type { CacheSchemaShape, EntitiesMap } from './schema';
 import type { ParamMap, ParamValues } from './types';
 
+/**
+ * Structured cache-key object produced by a `KeyFactory`; carries a primary tag for logging, the
+ * full invalidation fanout, and a qualifier-suffixed read tag for adapter lookups.
+ *
+ * @example
+ * ```ts
+ * const key = cache.keys.product({ tenant: shop, id: '123' });
+ * const data = await cache.wrap(key, () => fetchProduct('123'));
+ * ```
+ */
 export interface CacheKey {
+    /** The leaf tag without qualifier suffix, used in log messages to identify the cache entry. */
     primary: string; // leaf tag, used in logs
+    /** Full fanout from deepest (most specific) to shallowest (namespace root), used to populate the tag index on write. */
     tags: string[]; // full fanout, deepest → shallowest, for invalidation indexing
+    /** Lookup key for the adapter's `read`/`write` calls; equals `primary` when no qualifier is set, or `primary + "::" + qualifierKey` when a qualifier is present. */
     readTag: string; // primary + qualifier suffix, used as cache lookup key
 }
 
@@ -12,10 +25,26 @@ type ParamsOf<D> = D extends { params: infer P } ? (P extends ParamMap ? P : und
 
 type KeyBuilderArg<T, Q, D> = { tenant?: T; qualifier?: Q } & ParamValues<ParamsOf<D>>;
 
+/**
+ * Per-entity key builder map derived from a `CacheSchemaShape`; each method accepts tenant,
+ * qualifier, and entity-specific param values and returns a fully resolved `CacheKey`.
+ *
+ * @example
+ * ```ts
+ * const key = cache.keys.product({ tenant: shop, qualifier: locale, id: '123' });
+ * ```
+ */
 export type KeyFactory<T = unknown, Q = unknown, E extends EntitiesMap = EntitiesMap> = {
     [K in keyof E]: (arg: KeyBuilderArg<T, Q, E[K]>) => CacheKey;
 };
 
+/**
+ * Constructs the `KeyFactory` object for a schema, generating one typed key-builder closure per
+ * declared entity that computes the full fanout and optional qualifier suffix.
+ *
+ * @param schema - The resolved schema shape defining entities, tenant, and qualifier configuration.
+ * @returns A `KeyFactory` where each method accepts entity-specific params and returns a fully resolved `CacheKey`.
+ */
 export function buildKeyFactory<NS extends string, T, Q, E extends EntitiesMap>(
     schema: CacheSchemaShape<NS, T, Q, E>,
 ): KeyFactory<T, Q, E> {

--- a/packages/tagtree/core/src/memory-adapter.ts
+++ b/packages/tagtree/core/src/memory-adapter.ts
@@ -7,10 +7,32 @@ interface Entry {
     expiresAt?: number;
 }
 
+/**
+ * Configuration for the in-process memory adapter; controls the LRU eviction ceiling so memory
+ * use stays bounded in long-running processes.
+ *
+ * @example
+ * ```ts
+ * const adapter = memoryAdapter({ maxEntries: 500 });
+ * ```
+ */
 export interface MemoryAdapterOptions {
+    /** Maximum number of entries held before the oldest entries are evicted. Defaults to `1000`. */
     maxEntries?: number;
 }
 
+/**
+ * Creates a synchronous, in-process `CacheAdapter` backed by a `Map` with LRU eviction,
+ * per-tag invalidation tracking, and optional TTL expiry; suitable for unit tests and
+ * single-process environments where a shared cache store is not available.
+ *
+ * @param opts - Optional configuration; `maxEntries` caps the LRU store size.
+ * @returns A `CacheAdapter` instance backed by in-process storage.
+ * @example
+ * ```ts
+ * const cache = createCacheInstance(productSchema, memoryAdapter({ maxEntries: 200 }));
+ * ```
+ */
 export function memoryAdapter(opts: MemoryAdapterOptions = {}): CacheAdapter {
     const maxEntries = opts.maxEntries ?? 1000;
     const store = new Map<string, Entry>();

--- a/packages/tagtree/core/src/schema.ts
+++ b/packages/tagtree/core/src/schema.ts
@@ -1,30 +1,98 @@
 import type { EntityDecl, ParamMap } from './types';
 
+/**
+ * Declares how a tenant value maps to a cache-key prefix; the `key` function serializes the
+ * tenant to its string segment, while `extraTags` injects additional per-tenant invalidation
+ * tags such as a shop's custom domain alias.
+ *
+ * @example
+ * ```ts
+ * const tenant: TenantConfig<Shop> = {
+ *     type: {} as Shop,
+ *     key: (shop) => shop.id,
+ *     extraTags: (shop) => shop.domains,
+ * };
+ * ```
+ */
 export interface TenantConfig<T> {
+    /** Phantom field carrying the TypeScript type of the tenant value for inference. */
     type: T;
+    /** Derives the string segment that prefixes all cache tags for this tenant. */
     key(t: T): string;
+    /** Optional function that returns additional tag suffixes to include alongside the tenant root tag during fanout. */
     extraTags?(t: T): string[];
 }
 
+/**
+ * Declares how a qualifier value (e.g., a locale or currency code) appends a `::key` suffix to
+ * read tags, isolating cache entries for the same entity but different request contexts without
+ * duplicating the invalidation tag hierarchy.
+ *
+ * @example
+ * ```ts
+ * const qualifier: QualifierConfig<string> = {
+ *     type: '' as string,
+ *     key: (locale) => locale,
+ * };
+ * ```
+ */
 export interface QualifierConfig<Q> {
+    /** Phantom field carrying the TypeScript type of the qualifier value for inference. */
     type: Q;
+    /** Derives the qualifier string that is appended to the primary tag with `::` as separator. */
     key(q: Q): string;
 }
 
+/**
+ * Constraint type for the `entities` record passed to `defineCache`; maps entity names to their
+ * `EntityDecl` shapes, ensuring all values conform to the expected param and parent structure
+ * before the schema is frozen.
+ *
+ * @example
+ * ```ts
+ * const entities = {
+ *     product: { params: { id: str } },
+ *     collection: { params: { handle: str }, parents: ['product'] },
+ * } satisfies EntitiesMap;
+ * ```
+ */
 export type EntitiesMap = Record<string, EntityDecl<ParamMap | undefined, readonly string[]>>;
 
+/**
+ * Fully-resolved schema descriptor held at runtime; carries namespace, optional tenant and
+ * qualifier configs, and the entity declarations that drive key building and fanout expansion.
+ *
+ * @example
+ * ```ts
+ * const schema: CacheSchemaShape = defineCache({ namespace: 'commerce', entities: {} }).schema;
+ * ```
+ */
 export interface CacheSchemaShape<
     NS extends string = string,
     T = unknown,
     Q = unknown,
     E extends EntitiesMap = EntitiesMap,
 > {
+    /** Top-level dotted-path prefix applied to all tags produced by this schema; must not contain `.`. */
     namespace: NS;
+    /** Optional tenant axis config; when present, all cache tags are scoped per tenant value. */
     tenant?: TenantConfig<T>;
+    /** Optional qualifier axis config; when present, read tags gain a per-qualifier `::key` suffix. */
     qualifier?: QualifierConfig<Q>;
+    /** Map of entity names to their parameter and parent declarations. */
     entities: E;
 }
 
+/**
+ * Opaque wrapper returned by `defineCache`; wraps the resolved `CacheSchemaShape` to prevent
+ * callers from constructing or mutating the shape directly after validation.
+ *
+ * @example
+ * ```ts
+ * const productSchema: CacheSchema = defineCache({ namespace: 'commerce', entities: {} });
+ * const cache = createCacheInstance(productSchema, memoryAdapter());
+ * ```
+ */
 export interface CacheSchema<
     NS extends string = string,
     T = unknown,
@@ -34,6 +102,24 @@ export interface CacheSchema<
     schema: CacheSchemaShape<NS, T, Q, E>;
 }
 
+/**
+ * Validates and freezes a cache schema definition, rejecting namespace or entity names that
+ * contain `.` (which would produce ambiguous dotted tags), then returns a `CacheSchema` ready
+ * to pass to `createCacheInstance`.
+ *
+ * @param input - Raw schema definition with namespace, optional tenant and qualifier configs, and entity declarations.
+ * @returns A validated `CacheSchema` wrapping the resolved shape.
+ * @throws {Error} When `input.namespace` contains `.`.
+ * @throws {Error} When any entity name in `input.entities` contains `.`.
+ * @example
+ * ```ts
+ * const productSchema = defineCache({
+ *     namespace: 'commerce',
+ *     tenant: { type: {} as Shop, key: (s) => s.id },
+ *     entities: { product: { params: { id: str } } },
+ * });
+ * ```
+ */
 export function defineCache<const NS extends string, T, Q, const E extends EntitiesMap>(input: {
     namespace: NS;
     tenant?: TenantConfig<T>;

--- a/packages/tagtree/core/src/types.ts
+++ b/packages/tagtree/core/src/types.ts
@@ -1,16 +1,79 @@
 declare const brand: unique symbol;
+
+/**
+ * Nominal branding wrapper that makes otherwise structurally equivalent types distinguishable at
+ * the type level; used to prevent `str` and `num` param tokens from being swapped accidentally.
+ *
+ * @example
+ * ```ts
+ * // EntityDecl params use Brand to distinguish string vs number slots.
+ * const entities = { product: { params: { id: str, rank: num } } };
+ * ```
+ */
 export type Brand<T> = { readonly [brand]: T };
 
+/**
+ * Union of the two supported cache-key param kinds (`str` and `num`); the type-level token
+ * callers assign to each field in a `ParamMap` to declare its runtime shape.
+ *
+ * @example
+ * ```ts
+ * const paramKind: ParamType = str; // or `num`
+ * ```
+ */
 export type ParamType = Brand<string> | Brand<number>;
 
+/**
+ * Unwraps a `ParamType` brand token to the concrete `string` or `number` type it represents;
+ * used by `ParamValues` to derive the runtime argument type for each declared entity param.
+ *
+ * @example
+ * ```ts
+ * type IdType = ParamTypeShape<typeof str>; // string
+ * type RankType = ParamTypeShape<typeof num>; // number
+ * ```
+ */
 export type ParamTypeShape<P extends ParamType> = P extends Brand<infer S> ? S : never;
 
+/**
+ * Type constraint for the `params` field of an `EntityDecl`; maps param names to their `ParamType`
+ * brand tokens, which `ParamValues` later unfolds into concrete `string` or `number` values.
+ *
+ * @example
+ * ```ts
+ * const productParams: ParamMap = { id: str, version: num };
+ * ```
+ */
 export type ParamMap = Record<string, ParamType>;
 
+/**
+ * Converts a `ParamMap` into the corresponding runtime argument shape where each branded token
+ * is replaced by its concrete `string` or `number` type; used to type the entity-specific
+ * arguments accepted by `KeyFactory` methods and `InvalidateNamespace` entity methods.
+ *
+ * @example
+ * ```ts
+ * type ProductArgs = ParamValues<{ id: typeof str; rank: typeof num }>;
+ * // { id: string; rank: number }
+ * ```
+ */
 export type ParamValues<P extends ParamMap | undefined> = P extends ParamMap
     ? { [K in keyof P]: ParamTypeShape<P[K]> }
     : {};
 
+/**
+ * Declares a single entity within a cache schema, specifying the optional params it accepts for
+ * leaf-level key building and the parent entity names whose cache entries should also be
+ * invalidated when this entity is purged.
+ *
+ * @example
+ * ```ts
+ * const entities = {
+ *     product: { params: { id: str } },
+ *     collection: { params: { handle: str }, parents: ['product'] },
+ * } satisfies EntitiesMap;
+ * ```
+ */
 export interface EntityDecl<
     P extends ParamMap | undefined = undefined,
     R extends readonly string[] = readonly never[],
@@ -19,5 +82,24 @@ export interface EntityDecl<
     parents?: R;
 }
 
+/**
+ * Brand token that marks a `ParamMap` field as accepting a `string` value at runtime; assign to
+ * entity param fields that identify records by text keys such as handles, slugs, or GIDs.
+ *
+ * @example
+ * ```ts
+ * const entities = { product: { params: { id: str, handle: str } } };
+ * ```
+ */
 export const str = {} as Brand<string>;
+
+/**
+ * Brand token that marks a `ParamMap` field as accepting a `number` value at runtime; assign to
+ * entity param fields that identify records by numeric indices, version counters, or integer IDs.
+ *
+ * @example
+ * ```ts
+ * const entities = { variant: { params: { rank: num } } };
+ * ```
+ */
 export const num = {} as Brand<number>;


### PR DESCRIPTION
## Summary
Adds JSDoc to all in-scope symbols in `packages/tagtree/core` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

## Counts
- Tier-1 symbols documented: 34
- Tier-2 symbols documented: 2
- Files touched: 11

## Verification
- [x] `pnpm --filter @tagtree/core typecheck` passes
- [x] `pnpm --filter @tagtree/core lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (no logic changes)
- [x] Changeset added (`patch`)