### PR TITLE
docs(cart-core): backfill jsdoc on functions and components

### DIFF
--- a/.changeset/jsdoc-cart-core.md
+++ b/.changeset/jsdoc-cart-core.md
@@ -1,0 +1,5 @@
+---
+'@nordcom/cart-core': patch
+---
+
+Backfill JSDoc on public/internal symbols.

--- a/packages/cart/core/src/adapter.ts
+++ b/packages/cart/core/src/adapter.ts
@@ -1,5 +1,17 @@
 import type { AdapterCtx, BuyerIdentity, Cart, CartExt, KV, NewCartLine } from './types';
 
+/**
+ * Feature flags advertised by every {@link CartAdapter}. The kernel checks
+ * these before calling optional adapter methods, allowing hosts to also branch
+ * on capabilities without probing method presence at runtime.
+ *
+ * @example
+ * ```ts
+ * if (kernel.capabilities.giftCards) {
+ *   await kernel.mutate(ctx, { kind: 'apply-gift-card', code: 'GIFT123' });
+ * }
+ * ```
+ */
 export type CartCapabilities = {
     giftCards: boolean;
     multipleDiscountCodes: boolean;
@@ -10,11 +22,51 @@ export type CartCapabilities = {
     customMutations: readonly string[];
 };
 
+/**
+ * Handler registered on a {@link CartAdapter} for a named custom mutation —
+ * an operation with no first-class kernel method. Every name declared in
+ * `CartCapabilities.customMutations` must map to a handler of this type.
+ *
+ * @param ctx - Adapter context threaded from the kernel dispatch.
+ * @param args.cartId - Cart to mutate.
+ * @param args.payload - Arbitrary mutation payload; its shape is
+ *   handler-defined and opaque to the kernel.
+ * @returns The updated cart after the custom operation completes.
+ * @example
+ * ```ts
+ * const handler: CustomMutationHandler = async (ctx, { cartId, payload }) => {
+ *   const lines = (payload as { variantId: string }[]).map((v) => ({ ...v, quantity: 1 }));
+ *   return myAdapter.addLines(ctx, { cartId, lines });
+ * };
+ * ```
+ */
 export type CustomMutationHandler<TExt extends CartExt = {}> = (
     ctx: AdapterCtx,
     args: { cartId: string; payload: unknown },
 ) => Promise<Cart<TExt>>;
 
+/**
+ * Contract that every cart provider implementation satisfies. Adapters expose
+ * required CRUD operations and declare their optional capabilities so the kernel
+ * can gate advanced mutations without probing method presence.
+ *
+ * @example
+ * ```ts
+ * class ShopifyAdapter implements CartAdapter {
+ *   readonly type = 'shopify';
+ *   readonly capabilities: CartCapabilities = {
+ *     giftCards: true, multipleDiscountCodes: true,
+ *     buyerIdentity: true, notes: true, cartAttributes: true,
+ *     lineAttributes: true, customMutations: [],
+ *   };
+ *   async getCart(ctx, { cartId }) { ... }
+ *   async createCart(ctx, args) { ... }
+ *   async addLines(ctx, args) { ... }
+ *   async updateLines(ctx, args) { ... }
+ *   async removeLines(ctx, args) { ... }
+ * }
+ * ```
+ */
 export interface CartAdapter<TExt extends CartExt = {}> {
     readonly type: string;
     readonly capabilities: CartCapabilities;

--- a/packages/cart/core/src/compose.ts
+++ b/packages/cart/core/src/compose.ts
@@ -1,6 +1,32 @@
 import type { AdapterCtx, Cart, CartMutation } from './types';
 
+/**
+ * Core mutation primitive: an async function that accepts a {@link CartMutation}
+ * and its dispatch context, and returns the resulting cart snapshot.
+ *
+ * @example
+ * ```ts
+ * const terminal: MutationFn = async (mutation, ctx) =>
+ *   adapter.addLines(ctx, { cartId: ctx.cartId ?? '', lines: [] });
+ * ```
+ */
 export type MutationFn = (mutation: CartMutation, ctx: AdapterCtx) => Promise<Cart>;
+
+/**
+ * Higher-order function that wraps a {@link MutationFn} to inject cross-cutting
+ * behavior (logging, retrying, tracing). Middleware layers compose into a single
+ * pipeline via {@link compose}.
+ *
+ * @example
+ * ```ts
+ * const timestamp: CartMiddleware = (next) => async (mutation, ctx) => {
+ *   console.time(mutation.kind);
+ *   const result = await next(mutation, ctx);
+ *   console.timeEnd(mutation.kind);
+ *   return result;
+ * };
+ * ```
+ */
 export type CartMiddleware = (next: MutationFn) => MutationFn;
 
 /**
@@ -11,6 +37,12 @@ export type CartMiddleware = (next: MutationFn) => MutationFn;
  * @param middleware - Layers from outermost to innermost.
  * @returns A higher-order function that wraps a terminal {@link MutationFn}
  *   into a single composed {@link MutationFn}.
+ * @example
+ * ```ts
+ * const pipeline = compose(logger(), retry({ attempts: 3, backoffMs: 100 }));
+ * const run = pipeline(terminal);
+ * await run({ kind: 'add-line', variantId: 'v_123', quantity: 1 }, ctx);
+ * ```
  */
 export function compose(...middleware: CartMiddleware[]): CartMiddleware {
     return (terminal: MutationFn): MutationFn => {

--- a/packages/cart/core/src/contract-tests.ts
+++ b/packages/cart/core/src/contract-tests.ts
@@ -2,6 +2,19 @@ import { describe, expect, it } from 'vitest';
 import type { CartAdapter } from './adapter';
 import type { AdapterCtx } from './types';
 
+/**
+ * Options accepted by {@link runCartAdapterContract}. Passed once per
+ * adapter under test; the suite name and factory are the only inputs the
+ * contract runner needs from the host test file.
+ *
+ * @example
+ * ```ts
+ * runCartAdapterContract({
+ *   name: 'mock',
+ *   factory: () => createMockCartAdapter(),
+ * });
+ * ```
+ */
 export interface RunCartAdapterContractOpts {
     name: string;
     factory: () => CartAdapter | Promise<CartAdapter>;
@@ -21,6 +34,17 @@ export interface RunCartAdapterContractOpts {
  *
  * @param opts.name - Human label appended to the `describe` block.
  * @param opts.factory - Builds a fresh adapter for each test; may be async.
+ * @example
+ * ```ts
+ * // In my-adapter.test.ts:
+ * import { runCartAdapterContract } from '@nordcom/cart-core/contract-tests';
+ * import { createMockCartAdapter } from '@nordcom/cart-core/mock-adapter';
+ *
+ * runCartAdapterContract({
+ *   name: 'mock',
+ *   factory: () => createMockCartAdapter(),
+ * });
+ * ```
  */
 export function runCartAdapterContract(opts: RunCartAdapterContractOpts): void {
     describe(`cart adapter contract: ${opts.name}`, () => {

--- a/packages/cart/core/src/errors.ts
+++ b/packages/cart/core/src/errors.ts
@@ -3,11 +3,24 @@
  * `error.name` rather than `instanceof` because cart-core errors can cross
  * package boundaries (SSR → client, worker → main) where the constructor
  * identity isn't preserved.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await kernel.mutate(ctx, mutation);
+ * } catch (err) {
+ *   if ((err as CartError).name === 'CartError') console.error(err.message);
+ * }
+ * ```
  */
 export class CartError extends Error {
     /**
      * @param message - Human-readable description suitable for logs.
      * @param cause - Optional underlying error chained for diagnostics.
+     * @example
+     * ```ts
+     * throw new CartError('unexpected provider response', originalError);
+     * ```
      */
     constructor(
         message: string,
@@ -21,10 +34,20 @@ export class CartError extends Error {
 /**
  * Thrown by adapters when a cart id is resolvable in the request but no cart
  * exists upstream — distinct from a transport failure.
+ *
+ * @example
+ * ```ts
+ * const cart = carts.get(cartId);
+ * if (!cart) throw new CartNotFoundError(cartId);
+ * ```
  */
 export class CartNotFoundError extends CartError {
     /**
      * @param cartId - The missing cart identifier, included in the message.
+     * @example
+     * ```ts
+     * throw new CartNotFoundError('cart_abc123');
+     * ```
      */
     constructor(public readonly cartId: string) {
         super(`Cart not found: ${cartId}`);
@@ -35,11 +58,24 @@ export class CartNotFoundError extends CartError {
 /**
  * Thrown for transport / upstream-API failures (network, 5xx, malformed
  * payloads). Retry middleware treats this as retryable.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   response = await fetch(endpoint);
+ * } catch (err) {
+ *   throw new CartProviderError('network request failed', err);
+ * }
+ * ```
  */
 export class CartProviderError extends CartError {
     /**
      * @param message - Cause summary for logs.
      * @param cause - Underlying error preserved for diagnostics.
+     * @example
+     * ```ts
+     * throw new CartProviderError('upstream returned 503', fetchError);
+     * ```
      */
     constructor(message: string, cause?: unknown) {
         super(message, cause);
@@ -47,17 +83,41 @@ export class CartProviderError extends CartError {
     }
 }
 
+/**
+ * A single field-scoped validation error returned by the upstream provider.
+ * Consumers display these to users; `field` is `undefined` when the error is
+ * not attributable to a specific input field.
+ *
+ * @example
+ * ```ts
+ * const entries: CartUserErrorEntry[] = [
+ *   { field: 'discountCode', message: 'Code has expired' },
+ * ];
+ * throw new CartUserError(entries);
+ * ```
+ */
 export type CartUserErrorEntry = { field?: string; message: string };
 
 /**
  * Thrown when the upstream provider rejects a mutation due to caller-supplied
  * input (e.g. invalid discount code, quantity exceeds stock). Retry middleware
  * does NOT retry these.
+ *
+ * @example
+ * ```ts
+ * if (response.userErrors.length > 0) {
+ *   throw new CartUserError(response.userErrors);
+ * }
+ * ```
  */
 export class CartUserError extends CartError {
     /**
      * @param userErrors - Field-scoped messages from the provider; surfaced
      *   back to the UI for display.
+     * @example
+     * ```ts
+     * throw new CartUserError([{ field: 'discountCode', message: 'Code has expired' }]);
+     * ```
      */
     constructor(public readonly userErrors: CartUserErrorEntry[]) {
         super(userErrors.map((e) => e.message).join('; '));
@@ -68,11 +128,20 @@ export class CartUserError extends CartError {
 /**
  * Thrown by the kernel when a mutation requires a capability the active
  * adapter doesn't advertise (e.g. gift cards on a provider without them).
+ *
+ * @example
+ * ```ts
+ * if (!caps.giftCards) throw new CartCapabilityUnsupportedError('giftCards');
+ * ```
  */
 export class CartCapabilityUnsupportedError extends CartError {
     /**
      * @param capability - Capability name as declared on
      *   {@link CartCapabilities}, surfaced for diagnostics + UI.
+     * @example
+     * ```ts
+     * throw new CartCapabilityUnsupportedError('multipleDiscountCodes');
+     * ```
      */
     constructor(public readonly capability: string) {
         super(`Capability not supported: ${capability}`);

--- a/packages/cart/core/src/events.ts
+++ b/packages/cart/core/src/events.ts
@@ -1,5 +1,17 @@
 import type { Cart, CartLine, CartMutation, ILogger } from './types';
 
+/**
+ * Discriminated union of every lifecycle event the cart kernel can emit.
+ * Consumers subscribe via {@link CartEventBus.on} and switch on `event.type`
+ * to handle the specific variant they care about.
+ *
+ * @example
+ * ```ts
+ * bus.on('cart.updated', (event: CartEvent & { type: 'cart.updated' }) => {
+ *   analytics.track('cart_updated', { cartId: event.cart.id });
+ * });
+ * ```
+ */
 export type CartEvent =
     | { type: 'cart.created'; cart: Cart }
     | { type: 'cart.updated'; cart: Cart; mutation: CartMutation; source: 'self' | 'broadcast' }
@@ -8,12 +20,50 @@ export type CartEvent =
     | { type: 'cart.line.removed'; lineId: string; cart: Cart }
     | { type: 'cart.cleared' };
 
+/**
+ * Union of the string literal type discriminants for every {@link CartEvent}
+ * variant. Use as a constraint when narrowing to a specific event type or when
+ * parameterizing {@link CartEventHandler}.
+ *
+ * @example
+ * ```ts
+ * function subscribe(bus: CartEventBus, type: CartEventType) {
+ *   return bus.on(type, (event) => console.log(event));
+ * }
+ * ```
+ */
 export type CartEventType = CartEvent['type'];
 
+/**
+ * Callback signature for a subscriber to a specific {@link CartEvent} variant.
+ * The generic narrows the `event` parameter to exactly the variant identified
+ * by `E`, so handlers receive strongly-typed payloads without casting.
+ *
+ * @example
+ * ```ts
+ * const onCreated: CartEventHandler<'cart.created'> = (event) => {
+ *   console.log('new cart', event.cart.id);
+ * };
+ * ```
+ */
 export type CartEventHandler<E extends CartEventType> = (
     event: Extract<CartEvent, { type: E }>,
 ) => void | Promise<void>;
 
+/**
+ * In-process pub/sub channel through which the kernel broadcasts cart
+ * lifecycle events. Returned by {@link createEventBus}; passed to
+ * {@link createCart} internally and exposed on the returned {@link CartKernel}
+ * via its `on` method.
+ *
+ * @example
+ * ```ts
+ * const bus = createEventBus({ logger: consoleLogger });
+ * const off = bus.on('cart.updated', (e) => syncStore(e.cart));
+ * // later:
+ * off(); // unsubscribe
+ * ```
+ */
 export interface CartEventBus {
     on<E extends CartEventType>(type: E, handler: CartEventHandler<E>): () => void;
     emit(event: CartEvent): void;
@@ -28,6 +78,13 @@ export interface CartEventBus {
  * @param opts.logger - Sink for handler errors; failures are swallowed and
  *   surfaced via `logger.warn`.
  * @returns A {@link CartEventBus} with `on` (returns dispose) and `emit`.
+ * @example
+ * ```ts
+ * const bus = createEventBus({ logger: consoleLogger });
+ * const off = bus.on('cart.created', (e) => console.log('created', e.cart.id));
+ * bus.emit({ type: 'cart.cleared' });
+ * off();
+ * ```
  */
 export function createEventBus(opts: { logger: ILogger }): CartEventBus {
     const handlers = new Map<CartEventType, Set<CartEventHandler<CartEventType>>>();

--- a/packages/cart/core/src/idempotency-store.ts
+++ b/packages/cart/core/src/idempotency-store.ts
@@ -1,5 +1,18 @@
 import type { Cart } from './types';
 
+/**
+ * Backing store contract for the {@link idempotency} middleware. Implementations
+ * persist successful mutation results keyed by idempotency token so that
+ * duplicate requests within the TTL window replay the cached cart without
+ * re-invoking the adapter.
+ *
+ * @example
+ * ```ts
+ * const store: IdempotencyStore = memoryIdempotencyStore();
+ * await store.set('idem-key', cart, 30_000);
+ * const hit = await store.get('idem-key');
+ * ```
+ */
 export interface IdempotencyStore {
     get(key: string): Promise<{ result: Cart; recordedAt: number } | null>;
     set(key: string, result: Cart, ttlMs: number): Promise<void>;
@@ -11,6 +24,13 @@ export interface IdempotencyStore {
  * lazily expire on read; there is no background sweep.
  *
  * @returns An ephemeral store with no cross-process coordination.
+ * @example
+ * ```ts
+ * const kernel = createCart({
+ *   adapter,
+ *   middleware: [idempotency({ store: memoryIdempotencyStore(), windowMs: 30_000 })],
+ * });
+ * ```
  */
 export function memoryIdempotencyStore(): IdempotencyStore {
     const map = new Map<string, { result: Cart; recordedAt: number; expiresAt: number }>();

--- a/packages/cart/core/src/kernel.ts
+++ b/packages/cart/core/src/kernel.ts
@@ -5,6 +5,18 @@ import { type CartEvent, type CartEventHandler, type CartEventType, createEventB
 import type { AdapterCtx, BuyerIdentity, Cart, CartExt, CartMutation, ILogger, NewCartLine } from './types';
 import { consoleLogger } from './types';
 
+/**
+ * Host-facing surface returned by {@link createCart}. Exposes typed read,
+ * create, and mutate operations that run through the middleware chain and
+ * broadcast lifecycle events without exposing the underlying adapter directly.
+ *
+ * @example
+ * ```ts
+ * const kernel: CartKernel = createCart({ adapter });
+ * const cart = await kernel.create(ctx);
+ * await kernel.mutate(ctx, { kind: 'add-line', variantId: 'v_1', quantity: 1 });
+ * ```
+ */
 export interface CartKernel<TExt extends CartExt = {}, TShop = unknown> {
     readonly type: string;
     readonly capabilities: CartCapabilities;
@@ -17,6 +29,20 @@ export interface CartKernel<TExt extends CartExt = {}, TShop = unknown> {
     on<E extends CartEventType>(type: E, handler: CartEventHandler<E>): () => void;
 }
 
+/**
+ * Configuration bag passed to {@link createCart}. Declares the adapter,
+ * optional middleware pipeline, and an optional logger override for the
+ * internal event bus.
+ *
+ * @example
+ * ```ts
+ * const opts: CreateCartOpts = {
+ *   adapter: myAdapter,
+ *   middleware: [logger(), retry({ attempts: 3, backoffMs: 200 })],
+ * };
+ * const kernel = createCart(opts);
+ * ```
+ */
 export interface CreateCartOpts<TExt extends CartExt = {}, _TShop = unknown> {
     adapter: CartAdapter<TExt>;
     middleware?: CartMiddleware[];
@@ -40,6 +66,15 @@ export interface CreateCartOpts<TExt extends CartExt = {}, _TShop = unknown> {
  * @param opts.logger - Logger threaded into the event bus for handler-error
  *   surfacing. Defaults to {@link consoleLogger}.
  * @returns A {@link CartKernel} ready to read / create / mutate.
+ * @example
+ * ```ts
+ * const kernel = createCart({
+ *   adapter: createMockCartAdapter(),
+ *   middleware: [logger(), retry({ attempts: 3, backoffMs: 100 })],
+ * });
+ * const cart = await kernel.create(ctx);
+ * await kernel.mutate(ctx, { kind: 'add-line', variantId: 'v_1', quantity: 2 });
+ * ```
  */
 export function createCart<TExt extends CartExt = {}, TShop = unknown>(
     opts: CreateCartOpts<TExt, TShop>,

--- a/packages/cart/core/src/middleware/analytics.ts
+++ b/packages/cart/core/src/middleware/analytics.ts
@@ -1,5 +1,17 @@
 import type { CartMiddleware } from '../compose';
 
+/**
+ * Callback injected into the {@link analytics} middleware to forward mutation
+ * outcome events to the host's analytics pipeline. Receives an event name and
+ * a structured attribute bag rather than raw cart objects.
+ *
+ * @example
+ * ```ts
+ * const emit: AnalyticsEmit = (event, attrs) => {
+ *   window.dataLayer?.push({ event, ...attrs });
+ * };
+ * ```
+ */
 export type AnalyticsEmit = (event: string, attrs: Record<string, unknown>) => void;
 
 /**
@@ -10,6 +22,13 @@ export type AnalyticsEmit = (event: string, attrs: Record<string, unknown>) => v
  *
  * @param opts.emit - Host analytics sink. Receives event name + attribute bag.
  * @returns A {@link CartMiddleware} that observes mutation outcomes.
+ * @example
+ * ```ts
+ * const kernel = createCart({
+ *   adapter,
+ *   middleware: [analytics({ emit: (event, attrs) => tracker.track(event, attrs) })],
+ * });
+ * ```
  */
 export function analytics(opts: { emit: AnalyticsEmit }): CartMiddleware {
     return (next) => async (mutation, ctx) => {

--- a/packages/cart/core/src/middleware/idempotency.ts
+++ b/packages/cart/core/src/middleware/idempotency.ts
@@ -10,6 +10,13 @@ import type { IdempotencyStore } from '../idempotency-store';
  * @param opts.store - Backing {@link IdempotencyStore} (memory, Redis, etc).
  * @param opts.windowMs - TTL applied when caching a successful result.
  * @returns A {@link CartMiddleware} that short-circuits duplicates.
+ * @example
+ * ```ts
+ * const kernel = createCart({
+ *   adapter,
+ *   middleware: [idempotency({ store: memoryIdempotencyStore(), windowMs: 30_000 })],
+ * });
+ * ```
  */
 export function idempotency(opts: { store: IdempotencyStore; windowMs: number }): CartMiddleware {
     return (next) => async (mutation, ctx) => {

--- a/packages/cart/core/src/middleware/logger.ts
+++ b/packages/cart/core/src/middleware/logger.ts
@@ -7,6 +7,13 @@ import type { CartMiddleware } from '../compose';
  * rethrowing.
  *
  * @returns A {@link CartMiddleware} that observes — never alters — the chain.
+ * @example
+ * ```ts
+ * const kernel = createCart({
+ *   adapter,
+ *   middleware: [logger()],
+ * });
+ * ```
  */
 export function logger(): CartMiddleware {
     return (next) => async (mutation, ctx) => {

--- a/packages/cart/core/src/middleware/retry.ts
+++ b/packages/cart/core/src/middleware/retry.ts
@@ -12,6 +12,13 @@ import type { CartMiddleware } from '../compose';
  * @param opts.backoffMs - Multiplier for linear backoff between attempts; set
  *   to `0` to disable sleeps (useful in tests).
  * @returns A {@link CartMiddleware} that retries retryable failures.
+ * @example
+ * ```ts
+ * const kernel = createCart({
+ *   adapter,
+ *   middleware: [retry({ attempts: 3, backoffMs: 200 })],
+ * });
+ * ```
  */
 export function retry(opts: { attempts: number; backoffMs: number }): CartMiddleware {
     return (next) => async (mutation, ctx) => {

--- a/packages/cart/core/src/middleware/tracing.ts
+++ b/packages/cart/core/src/middleware/tracing.ts
@@ -10,6 +10,13 @@ import type { ITracer } from '../types';
  * @param opts - Optional explicit tracer. If omitted, `ctx.tracer` is used;
  *   if both are absent the middleware degrades to a pass-through.
  * @returns A {@link CartMiddleware} that pipes mutations through a span.
+ * @example
+ * ```ts
+ * const kernel = createCart({
+ *   adapter,
+ *   middleware: [tracing({ tracer: openTelemetryTracer })],
+ * });
+ * ```
  */
 export function tracing(opts: { tracer?: ITracer }): CartMiddleware {
     return (next) => async (mutation, ctx) => {

--- a/packages/cart/core/src/mock-adapter.ts
+++ b/packages/cart/core/src/mock-adapter.ts
@@ -93,6 +93,20 @@ function recomputeTotalQuantity(cart: Cart): Cart {
     };
 }
 
+/**
+ * Options for {@link createMockCartAdapter}. All fields are optional; omitting
+ * them yields an everything-enabled adapter with zero latency and no injected
+ * failures.
+ *
+ * @example
+ * ```ts
+ * const opts: CreateMockCartAdapterOpts = {
+ *   capabilities: { giftCards: false },
+ *   latency: 50,
+ * };
+ * const adapter = createMockCartAdapter(opts);
+ * ```
+ */
 export interface CreateMockCartAdapterOpts {
     capabilities?: Partial<CartCapabilities>;
     seedCarts?: Cart[];
@@ -118,6 +132,13 @@ export interface CreateMockCartAdapterOpts {
  * @param opts.customMutations - Named custom-mutation handlers wired onto
  *   `adapter.customMutations`.
  * @returns A {@link CartAdapter} with an extra `__inspect()` escape hatch.
+ * @example
+ * ```ts
+ * const adapter = createMockCartAdapter({ latency: 0 });
+ * const kernel = createCart({ adapter });
+ * const cart = await kernel.create(ctx);
+ * expect(adapter.__inspect().carts).toHaveLength(1);
+ * ```
  */
 export function createMockCartAdapter(
     opts: CreateMockCartAdapterOpts = {},

--- a/packages/cart/core/src/money.ts
+++ b/packages/cart/core/src/money.ts
@@ -1,5 +1,41 @@
+/**
+ * ISO 4217 alphabetic currency code (e.g. `"USD"`, `"EUR"`, `"JPY"`). Used
+ * wherever a currency denomination is required in the cart API to ensure
+ * currency is always explicit and never inferred.
+ *
+ * @example
+ * ```ts
+ * const code: CurrencyCode = ctx.locale.currency;
+ * const zero = money.zero(code);
+ * ```
+ */
 export type CurrencyCode = string;
+
+/**
+ * Decimal-string money amount paired with its currency code, matching the
+ * shape returned by most provider APIs. Pass to {@link money.parse} to
+ * convert to integer cents before doing arithmetic.
+ *
+ * @example
+ * ```ts
+ * const price: Money = { amount: '12.99', currencyCode: 'USD' };
+ * const cents = money.parse(price);
+ * ```
+ */
 export type Money = { amount: string; currencyCode: CurrencyCode };
+
+/**
+ * Integer-cents money representation used for all arithmetic inside the cart
+ * kernel. Avoids floating-point rounding by working in the currency's minor
+ * units. Convert back to {@link Money} via {@link money.format}.
+ *
+ * @example
+ * ```ts
+ * const subtotal = money.parse(line.cost.subtotal);
+ * const tax = money.mul(subtotal, 0.1);
+ * const formatted = money.format(tax);
+ * ```
+ */
 export type MoneyCents = { cents: number; currencyCode: CurrencyCode };
 
 const scaleCache = new Map<CurrencyCode, number>();
@@ -34,6 +70,18 @@ function assertSameCurrency(a: MoneyCents, b: MoneyCents): void {
     }
 }
 
+/**
+ * Namespace of pure arithmetic helpers for {@link Money} and {@link MoneyCents}.
+ * Always work in cents (via `money.parse`) before arithmetic, then convert
+ * back with `money.format` — never do floating-point math on raw amount strings.
+ *
+ * @example
+ * ```ts
+ * const a = money.parse({ amount: '10.00', currencyCode: 'USD' });
+ * const b = money.parse({ amount: '3.50', currencyCode: 'USD' });
+ * const total = money.format(money.add(a, b)); // { amount: '13.50', currencyCode: 'USD' }
+ * ```
+ */
 export const money = {
     /**
      * Converts a decimal-string money amount into an integer-cents
@@ -41,6 +89,10 @@ export const money = {
      *
      * @param m - Money with decimal `amount` (e.g. `"12.34"`).
      * @returns Integer-cents money in the same currency.
+     * @example
+     * ```ts
+     * money.parse({ amount: '9.99', currencyCode: 'USD' }); // { cents: 999, currencyCode: 'USD' }
+     * ```
      */
     parse(m: Money): MoneyCents {
         const cents = Math.round(parseFloat(m.amount) * 10 ** scale(m.currencyCode));
@@ -52,26 +104,42 @@ export const money = {
      *
      * @param m - Integer-cents money.
      * @returns Decimal-string money in the same currency.
+     * @example
+     * ```ts
+     * money.format({ cents: 999, currencyCode: 'USD' }); // { amount: '9.99', currencyCode: 'USD' }
+     * ```
      */
     format(m: MoneyCents): Money {
         const s = scale(m.currencyCode);
         return { amount: (m.cents / 10 ** s).toFixed(s), currencyCode: m.currencyCode };
     },
     /**
+     * Adds two cent amounts in the same currency.
+     *
      * @param a - Left addend.
      * @param b - Right addend.
      * @returns `a + b` in `a.currencyCode`.
      * @throws Error when currencies differ.
+     * @example
+     * ```ts
+     * const total = money.add(subtotal, tax);
+     * ```
      */
     add(a: MoneyCents, b: MoneyCents): MoneyCents {
         assertSameCurrency(a, b);
         return { cents: a.cents + b.cents, currencyCode: a.currencyCode };
     },
     /**
+     * Subtracts one cent amount from another in the same currency.
+     *
      * @param a - Minuend.
      * @param b - Subtrahend.
      * @returns `a - b` in `a.currencyCode`.
      * @throws Error when currencies differ.
+     * @example
+     * ```ts
+     * const discount = money.sub(original, discounted);
+     * ```
      */
     sub(a: MoneyCents, b: MoneyCents): MoneyCents {
         assertSameCurrency(a, b);
@@ -83,43 +151,72 @@ export const money = {
      * @param a - Money amount.
      * @param n - Scalar multiplier.
      * @returns `a * n` in `a.currencyCode`.
+     * @example
+     * ```ts
+     * const lineTotal = money.mul(unitPrice, quantity);
+     * ```
      */
     mul(a: MoneyCents, n: number): MoneyCents {
         return { cents: Math.round(a.cents * n), currencyCode: a.currencyCode };
     },
     /**
+     * Tests whether two cent amounts are equal in value and currency.
+     *
      * @param a - Left side.
      * @param b - Right side.
      * @returns `true` iff equal in value and currency.
      * @throws Error when currencies differ.
+     * @example
+     * ```ts
+     * if (money.eq(price, money.zero('USD'))) console.log('free item');
+     * ```
      */
     eq(a: MoneyCents, b: MoneyCents): boolean {
         assertSameCurrency(a, b);
         return a.cents === b.cents;
     },
     /**
+     * Tests whether `a` is strictly less than `b`.
+     *
      * @param a - Left side.
      * @param b - Right side.
      * @returns `true` iff `a < b`.
      * @throws Error when currencies differ.
+     * @example
+     * ```ts
+     * if (money.lt(balance, total)) throw new Error('insufficient funds');
+     * ```
      */
     lt(a: MoneyCents, b: MoneyCents): boolean {
         assertSameCurrency(a, b);
         return a.cents < b.cents;
     },
     /**
+     * Tests whether `a` is strictly greater than `b`.
+     *
      * @param a - Left side.
      * @param b - Right side.
      * @returns `true` iff `a > b`.
      * @throws Error when currencies differ.
+     * @example
+     * ```ts
+     * if (money.gt(subtotal, threshold)) applyFreeShipping(cart);
+     * ```
      */
     gt(a: MoneyCents, b: MoneyCents): boolean {
         assertSameCurrency(a, b);
         return a.cents > b.cents;
     },
     /**
+     * Creates a zero-amount sentinel in the given currency, useful as an
+     * accumulator seed or a no-cost placeholder.
+     *
      * @param cc - Currency code.
      * @returns Zero amount in the requested currency.
+     * @example
+     * ```ts
+     * const total = lines.reduce((acc, l) => money.add(acc, money.parse(l.cost.subtotal)), money.zero('USD'));
+     * ```
      */
     zero(cc: CurrencyCode): MoneyCents {
         return { cents: 0, currencyCode: cc };

--- a/packages/cart/core/src/types.ts
+++ b/packages/cart/core/src/types.ts
@@ -2,8 +2,30 @@ import type { CurrencyCode, Money } from './money';
 
 export type { CurrencyCode, Money } from './money';
 
+/**
+ * Language-country-currency triple that parameterizes every adapter call.
+ * Ensures currency is always co-located with locale so adapters never have
+ * to infer it from context.
+ *
+ * @example
+ * ```ts
+ * const locale: LocaleTuple = { language: 'en', country: 'US', currency: 'USD' };
+ * const ctx: AdapterCtx = { shop: {}, locale, logger: consoleLogger };
+ * ```
+ */
 export type LocaleTuple = { language: string; country: string; currency: CurrencyCode };
 
+/**
+ * Optional contact details attached to an active cart to identify the buyer.
+ * Pass to `createCart` or via the `update-buyer-identity` mutation when the
+ * consumer logs in or checks out as a guest.
+ *
+ * @example
+ * ```ts
+ * const identity: BuyerIdentity = { email: 'buyer@example.com', countryCode: 'US' };
+ * await kernel.mutate(ctx, { kind: 'update-buyer-identity' });
+ * ```
+ */
 export type BuyerIdentity = {
     email?: string;
     phone?: string;
@@ -11,8 +33,29 @@ export type BuyerIdentity = {
     provider?: { type: string; data: Record<string, unknown> };
 };
 
+/**
+ * Extension slot that lets adapter authors attach arbitrary provider-specific
+ * data to {@link Cart} and {@link CartLine} without widening the core types.
+ * Pass a concrete shape as the `TExt` generic to unlock typed `custom` fields.
+ *
+ * @example
+ * ```ts
+ * type ShopifyExt = CartExt & { cart: { checkoutToken: string }; line: { sellingPlanId?: string } };
+ * type ShopifyCart = Cart<ShopifyExt>;
+ * ```
+ */
 export type CartExt = { cart?: unknown; line?: unknown };
 
+/**
+ * Snapshot of the variant-level product data attached to a cart line.
+ * Captured at add-to-cart time so the cart displays correct titles and prices
+ * even when the variant is later modified or removed in the catalog.
+ *
+ * @example
+ * ```ts
+ * const { productTitle, unitPrice } = line.merchandise;
+ * ```
+ */
 export type CartLineMerchandise = {
     id: string;
     productId: string;
@@ -30,6 +73,16 @@ export type CartLineMerchandise = {
     sku: string | null;
 };
 
+/**
+ * A single line item in a {@link Cart}, combining a quantity, merchandise
+ * snapshot, and line-level cost breakdown. The `L` generic carries optional
+ * provider-specific extensions (from {@link CartExt}).
+ *
+ * @example
+ * ```ts
+ * const totalItems = cart.lines.reduce((n, l) => n + l.quantity, 0);
+ * ```
+ */
 export type CartLine<L = {}> = {
     id: string;
     quantity: number;
@@ -40,6 +93,18 @@ export type CartLine<L = {}> = {
     custom: L;
 };
 
+/**
+ * Full cart state returned by the kernel after every read or mutation. The
+ * `TExt` generic carries provider-specific extensions added by the adapter.
+ * Treat this value as an immutable snapshot — the kernel always returns a new
+ * object after each mutation.
+ *
+ * @example
+ * ```ts
+ * const cart: Cart = await kernel.create(ctx);
+ * console.log(cart.totalQuantity, cart.cost.subtotal.amount);
+ * ```
+ */
 export type Cart<TExt extends CartExt = {}> = {
     id: string;
     providerType: string;
@@ -57,12 +122,41 @@ export type Cart<TExt extends CartExt = {}> = {
     custom: TExt['cart'];
 };
 
+/**
+ * Minimal input needed to add a variant to a cart. Passed to `createCart`
+ * or the `add-line` mutation; the adapter expands it into a full
+ * {@link CartLine} using catalog data from the provider.
+ *
+ * @example
+ * ```ts
+ * const line: NewCartLine = { variantId: 'gid://shopify/ProductVariant/1', quantity: 2 };
+ * await kernel.mutate(ctx, { kind: 'add-line', ...line });
+ * ```
+ */
 export type NewCartLine = {
     variantId: string;
     quantity: number;
     attributes?: Array<{ key: string; value: string }>;
 };
 
+/**
+ * Denormalized product data captured at add-to-cart time and carried on the
+ * `add-line` mutation. Allows UI layers to render optimistic line items before
+ * the adapter round-trip completes, without a separate catalog fetch.
+ *
+ * @example
+ * ```ts
+ * const snapshot: ProductSnapshot = {
+ *   variantId: variant.id,
+ *   productHandle: product.handle,
+ *   productTitle: product.title,
+ *   variantTitle: variant.title,
+ *   image: variant.image,
+ *   unitPrice: variant.price,
+ * };
+ * await kernel.mutate(ctx, { kind: 'add-line', variantId: variant.id, quantity: 1, snapshot });
+ * ```
+ */
 export type ProductSnapshot = {
     variantId: string;
     productHandle: string;
@@ -73,8 +167,29 @@ export type ProductSnapshot = {
     compareAtUnitPrice?: Money | null;
 };
 
+/**
+ * Generic key-value pair used for cart attributes and line item attributes.
+ * Adapters map these to provider-specific metadata fields.
+ *
+ * @example
+ * ```ts
+ * const attrs: KV[] = [{ key: 'gift_message', value: 'Happy birthday!' }];
+ * await kernel.mutate(ctx, { kind: 'update-attributes', attributes: attrs });
+ * ```
+ */
 export type KV = { key: string; value: string };
 
+/**
+ * Discriminated union of every operation the kernel can route to an adapter.
+ * Pass to {@link CartKernel.mutate}; the kernel dispatches on `kind` to the
+ * corresponding adapter method, guarded by {@link CartCapabilities}.
+ *
+ * @example
+ * ```ts
+ * const mutation: CartMutation = { kind: 'add-line', variantId: 'v_1', quantity: 2 };
+ * await kernel.mutate(ctx, mutation);
+ * ```
+ */
 export type CartMutation =
     | { kind: 'add-line'; variantId: string; quantity: number; attributes?: KV[]; snapshot?: ProductSnapshot }
     | { kind: 'update-line'; lineId: string; quantity: number }
@@ -88,8 +203,34 @@ export type CartMutation =
     | { kind: 'update-buyer-identity' }
     | { kind: 'custom'; name: string; payload: unknown };
 
+/**
+ * Wraps a {@link CartMutation} with an idempotency key for transport across
+ * the server-action boundary. Used by {@link SubmitMutation} implementations
+ * to carry the key alongside the mutation payload.
+ *
+ * @example
+ * ```ts
+ * const envelope: MutationEnvelope = {
+ *   mutation: { kind: 'add-line', variantId: 'v_1', quantity: 1 },
+ *   idempotencyKey: crypto.randomUUID(),
+ * };
+ * await submitMutation(envelope);
+ * ```
+ */
 export type MutationEnvelope = { mutation: CartMutation; idempotencyKey: string };
 
+/**
+ * Machine-readable failure code surfaced on the `reason` field of a failing
+ * {@link CartActionResult}. UI layers switch on this to decide whether to
+ * show a retry button, a validation message, or a fallback redirect.
+ *
+ * @example
+ * ```ts
+ * if (!result.ok && result.reason === 'user-error') {
+ *   showValidationErrors(result.userErrors ?? []);
+ * }
+ * ```
+ */
 export type CartActionFailureReason =
     | 'missing-shop'
     | 'missing-variant'
@@ -102,6 +243,19 @@ export type CartActionFailureReason =
     | 'network-error'
     | 'provider-error';
 
+/**
+ * Discriminated result returned by a {@link SubmitMutation} server action.
+ * On success, `ok: true` carries the updated cart. On failure, `ok: false`
+ * carries a {@link CartActionFailureReason} code, a human message, and
+ * optional field-scoped `userErrors` for display.
+ *
+ * @example
+ * ```ts
+ * const result = await submitMutation(envelope);
+ * if (result.ok) updateCart(result.cart);
+ * else showError(result.reason, result.message);
+ * ```
+ */
 export type CartActionResult<TExt extends CartExt = {}> =
     | { ok: true; cart: Cart<TExt> }
     | {
@@ -112,8 +266,33 @@ export type CartActionResult<TExt extends CartExt = {}> =
           cart?: Cart<TExt>;
       };
 
+/**
+ * Server-action signature that transport layers (Next.js, Remix, tRPC) implement
+ * to accept a {@link MutationEnvelope} from the client and return a
+ * {@link CartActionResult}. Wires the kernel into the framework's action
+ * pipeline while keeping the kernel itself framework-agnostic.
+ *
+ * @example
+ * ```ts
+ * const submitMutation: SubmitMutation = async (envelope) => {
+ *   const cart = await kernel.mutate({ ...ctx, idempotencyKey: envelope.idempotencyKey }, envelope.mutation);
+ *   return { ok: true, cart };
+ * };
+ * ```
+ */
 export type SubmitMutation<TExt extends CartExt = {}> = (envelope: MutationEnvelope) => Promise<CartActionResult<TExt>>;
 
+/**
+ * Minimal structured-logging interface threaded through {@link AdapterCtx}.
+ * Adapters and middleware log to this sink rather than `console` directly so
+ * hosts can route output to their existing log pipeline.
+ *
+ * @example
+ * ```ts
+ * const ctx: AdapterCtx = { shop: {}, locale, logger: consoleLogger };
+ * ctx.logger.info('cart created', { cartId: cart.id });
+ * ```
+ */
 export interface ILogger {
     debug: (msg: string, meta?: Record<string, unknown>) => void;
     info: (msg: string, meta?: Record<string, unknown>) => void;
@@ -121,6 +300,16 @@ export interface ILogger {
     error: (msg: string, meta?: Record<string, unknown>) => void;
 }
 
+/**
+ * Default {@link ILogger} implementation that prefixes every message with
+ * `[cart]` and writes to the platform `console`. Use as a drop-in when no
+ * custom logger is provided to {@link createCart}.
+ *
+ * @example
+ * ```ts
+ * const kernel = createCart({ adapter, logger: consoleLogger });
+ * ```
+ */
 export const consoleLogger: ILogger = {
     debug: (msg, meta) => console.debug(`[cart] ${msg}`, meta ?? ''),
     info: (msg, meta) => console.info(`[cart] ${msg}`, meta ?? ''),
@@ -128,6 +317,21 @@ export const consoleLogger: ILogger = {
     error: (msg, meta) => console.error(`[cart] ${msg}`, meta ?? ''),
 };
 
+/**
+ * Minimal tracing interface accepted by the {@link tracing} middleware and
+ * optionally supplied on {@link AdapterCtx}. Mirrors the OTel `Tracer` shape
+ * without a direct dependency so hosts can bridge any tracing backend.
+ *
+ * @example
+ * ```ts
+ * const tracer: ITracer = {
+ *   startSpan: async (name, attrs, fn) => {
+ *     const span = openTelemetry.tracer.startSpan(name, { attributes: attrs });
+ *     return fn({ recordException: (e) => span.recordException(e as Error), setAttribute: (k, v) => span.setAttribute(k, String(v)) });
+ *   },
+ * };
+ * ```
+ */
 export interface ITracer {
     startSpan<R>(
         name: string,
@@ -139,6 +343,21 @@ export interface ITracer {
     ): Promise<R>;
 }
 
+/**
+ * Immutable context threaded into every adapter call by the kernel. Carries
+ * shop identity, locale, logger, and optional per-request signals so adapters
+ * never reach for global state.
+ *
+ * @example
+ * ```ts
+ * const ctx: AdapterCtx = {
+ *   shop: shopRecord,
+ *   locale: { language: 'en', country: 'US', currency: 'USD' },
+ *   logger: consoleLogger,
+ *   idempotencyKey: crypto.randomUUID(),
+ * };
+ * ```
+ */
 export type AdapterCtx<TShop = unknown> = {
     shop: TShop;
     locale: LocaleTuple;


### PR DESCRIPTION
## Summary

Backfills JSDoc on all in-scope symbols in `packages/cart/core` per the [JSDoc Coverage Retrofit spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

This package had ~73% existing coverage; this PR fills the remaining gaps.

## Counts

| Tier | Symbols added/completed |
|------|------------------------|
| Tier-1 (public API) | 38 |
| Tier-2 (internal) | 0 new (all 4 internal helpers in mock-adapter.ts were already documented) |
| Files touched | 15 |

## Verification checklist

- [x] `pnpm --filter @nordcom/cart-core typecheck` passes
- [x] `pnpm --filter @nordcom/cart-core lint --write` — no fixes applied
- [x] Diff is insertions-only; all changes are in `packages/cart/core/src/`
- [x] No code changes — JSDoc and whitespace only
- [x] Changeset included (`.changeset/jsdoc-cart-core.md`, `patch`)
- [x] Existing JSDoc blocks left intact
