### PR TITLE
docs(shopify-graphql): fix jsdoc placement on FragmentOf

### DIFF
--- a/packages/shopify-graphql/src/graphql.ts
+++ b/packages/shopify-graphql/src/graphql.ts
@@ -99,6 +99,10 @@ export type ResultOf<TDoc> = GqlResultOf<TDoc>;
  */
 export type VariablesOf<TDoc> = GqlVariablesOf<TDoc>;
 
+// Structural equivalent of gql.tada's non-exported `FragmentDefDecorationLike` — needed to
+// express a fragment-document constraint on FragmentOf without importing a private symbol.
+type FragmentDecorationLike = { fragment: unknown; on: unknown; masked: unknown };
+
 /**
  * Masked shape of a fragment as it appears before being unwrapped by `readFragment`.
  *
@@ -124,10 +128,6 @@ export type VariablesOf<TDoc> = GqlVariablesOf<TDoc>;
  * }
  * ```
  */
-// Structural equivalent of gql.tada's non-exported `FragmentDefDecorationLike` — needed to
-// express a fragment-document constraint on FragmentOf without importing a private symbol.
-type FragmentDecorationLike = { fragment: unknown; on: unknown; masked: unknown };
-
 export type FragmentOf<TFragment extends GqlTadaDocumentNode<unknown, unknown, FragmentDecorationLike>> =
     TFragment extends GqlTadaDocumentNode<unknown, unknown, FragmentDecorationLike> ? GqlFragmentOf<TFragment> : never;
 


### PR DESCRIPTION
## Summary
Reviewer flagged on the merged PR #1961 that the `FragmentOf` JSDoc block was binding to the internal `FragmentDecorationLike` type (because TypeScript binds JSDoc to the immediately-following declaration). Moves the block to sit above `export type FragmentOf<...>` so it documents the actual public symbol.

## Verification
- [x] `pnpm --filter @nordcom/commerce-shopify-graphql typecheck` passes
- [x] `pnpm --filter @nordcom/commerce-shopify-graphql lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (4 inserts / 4 deletes — block moved, no logic touched)