### PR TITLE
docs(marketing-common): backfill jsdoc on functions and components

### DIFF
--- a/packages/marketing-common/src/index.ts
+++ b/packages/marketing-common/src/index.ts
@@ -1,5 +1,18 @@
 import type { NordstarTheme } from '@nordcom/nordstar';
 
+/**
+ * Nordstar design system theme for the marketing applications, pinning the brand accent colors and CSS variable font references.
+ *
+ * @example
+ * ```tsx
+ * import { Theme } from '@nordcom/commerce-marketing-common';
+ * import { NordstarProvider } from '@nordcom/nordstar';
+ *
+ * <NordstarProvider theme={Theme}>
+ *     {children}
+ * </NordstarProvider>
+ * ```
+ */
 export const Theme: NordstarTheme = {
     accents: {
         primary: '#ed1e79',


### PR DESCRIPTION
## Summary
Adds JSDoc to all in-scope symbols in `packages/marketing-common` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

## Counts
- Tier-1 symbols documented: 1
- Tier-2 symbols documented: 0
- Files touched: 1

## Verification
- [x] `pnpm --filter @nordcom/commerce-marketing-common typecheck` passes
- [x] `pnpm --filter @nordcom/commerce-marketing-common lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (no logic changes)