### PR TITLE
docs(shopify-html): backfill jsdoc on functions and components

### DIFF
--- a/packages/shopify-html/src/to-plain-text.ts
+++ b/packages/shopify-html/src/to-plain-text.ts
@@ -18,6 +18,13 @@ const BLOCK_TAGS = new Set([
     'blockquote',
 ]);
 
+/**
+ * Recursively accumulates text from a parsed HTML node, flushing to `lines` at block-level element boundaries.
+ *
+ * @param node - The parsed HTML node to visit.
+ * @param lines - Collector for completed line strings; a new entry is pushed each time a block boundary is crossed.
+ * @param current - Mutable string accumulator holding text not yet flushed to `lines`.
+ */
 function walk(node: Node, lines: string[], current: { value: string }): void {
     if (node.nodeType === NodeType.TEXT_NODE) {
         current.value += node.text;
@@ -47,6 +54,17 @@ function walk(node: Node, lines: string[], current: { value: string }): void {
     }
 }
 
+/**
+ * Converts a Shopify-origin HTML string to plain text, inserting newlines at block-element boundaries to preserve paragraph structure.
+ *
+ * @param html - Raw Shopify HTML string to convert; accepts null or undefined.
+ * @returns Newline-separated plain-text content, or an empty string when the input is blank or un-parseable.
+ * @example
+ * ```ts
+ * const text = toPlainText('<p>Hello <strong>world</strong></p><p>Another paragraph.</p>');
+ * // "Hello world\nAnother paragraph."
+ * ```
+ */
 export function toPlainText(html: string | null | undefined): string {
     const root = normalize(html);
     if (!root) return '';

--- a/packages/shopify-html/src/to-react-nodes.tsx
+++ b/packages/shopify-html/src/to-react-nodes.tsx
@@ -28,11 +28,20 @@ const VOID_ELEMENTS = new Set([
     'wbr',
 ]);
 
+/**
+ * Options accepted by {@link toReactNodes} that let callers substitute custom React components for specific HTML tags during conversion.
+ */
 export type ToReactNodesOptions = {
     /** Override which component to render for a given tag. */
     components?: Partial<Record<keyof JSX.IntrinsicElements, ElementType>>;
 };
 
+/**
+ * Translates raw HTML attribute names to their React DOM equivalents, handling cases like `class` → `className` and `for` → `htmlFor`.
+ *
+ * @param raw - HTML attribute map as returned by the parser.
+ * @returns Attribute object with React-compatible property names substituted where applicable.
+ */
 function convertAttributes(raw: Record<string, string>): Record<string, string> {
     const out: Record<string, string> = {};
     for (const [name, value] of Object.entries(raw)) {
@@ -42,6 +51,14 @@ function convertAttributes(raw: Record<string, string>): Record<string, string> 
     return out;
 }
 
+/**
+ * Converts a single parsed HTML node to a React element, a text string, or null; recurses into child nodes for element nodes.
+ *
+ * @param node - Parsed HTML node to convert.
+ * @param key - React reconciliation key to assign to the created element.
+ * @param opts - Conversion options forwarded from the root call, including any tag-level component overrides.
+ * @returns A React element for element nodes, the raw text string for text nodes, or null for unrecognized or empty nodes.
+ */
 function nodeToReact(node: Node, key: string, opts: ToReactNodesOptions): ReactNode {
     if (node.nodeType === NodeType.TEXT_NODE) {
         return node.text;
@@ -68,6 +85,20 @@ function nodeToReact(node: Node, key: string, opts: ToReactNodesOptions): ReactN
     return createElement(Component, props, ...children);
 }
 
+/**
+ * Parses a Shopify-origin HTML string and returns a React node tree suitable for direct rendering, normalizing HTML attributes and optionally replacing tags with custom React components.
+ *
+ * @param html - Raw Shopify HTML string to convert; accepts null or undefined.
+ * @param opts - Conversion options; supply `components` to replace specific HTML tags with custom React components.
+ * @returns A React node wrapping the parsed content, or null when the input is blank or yields no renderable output.
+ * @example
+ * ```tsx
+ * const nodes = toReactNodes(product.descriptionHtml, {
+ *     components: { a: LinkComponent },
+ * });
+ * return <div>{nodes}</div>;
+ * ```
+ */
 export function toReactNodes(html: string | null | undefined, opts: ToReactNodesOptions = {}): ReactNode {
     const root = normalize(html);
     if (!root) return null;


### PR DESCRIPTION
## Summary
Adds JSDoc to all in-scope symbols in `packages/shopify-html` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

## Counts
- Tier-1 symbols documented: 3 (`toPlainText`, `toReactNodes`, `ToReactNodesOptions`)
- Tier-2 symbols documented: 3 (`walk`, `convertAttributes`, `nodeToReact`)
- Files touched: 2

## Verification
- [x] `pnpm --filter @nordcom/commerce-shopify-html typecheck` passes
- [x] `pnpm --filter @nordcom/commerce-shopify-html lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (no logic changes)