### PR TITLE
docs(cart-shopify): backfill jsdoc on functions and components

### DIFF
--- a/.changeset/jsdoc-cart-shopify.md
+++ b/.changeset/jsdoc-cart-shopify.md
@@ -1,0 +1,5 @@
+---
+'@nordcom/cart-shopify': patch
+---
+
+Backfill JSDoc on public/internal symbols.

--- a/packages/cart/shopify/src/testing.ts
+++ b/packages/cart/shopify/src/testing.ts
@@ -116,6 +116,18 @@ function toShopifyCart(c: InternalCart): unknown {
     };
 }
 
+/**
+ * Options for {@link mockShopifyTransport}. `failOn` lets test authors inject
+ * transport-level failures on specific Shopify mutation operations so the
+ * adapter's error-handling paths can be exercised without a live endpoint.
+ *
+ * @example
+ * ```ts
+ * const transport = mockShopifyTransport({
+ *     failOn: (op) => op === 'cartLinesAdd' ? new Error('network error') : null,
+ * });
+ * ```
+ */
 export interface MockShopifyTransportOpts {
     failOn?: (op: string, vars: Record<string, unknown>) => Error | null;
 }


### PR DESCRIPTION
## Summary
Adds JSDoc to all in-scope symbols in `packages/cart/shopify` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

## Counts
- Tier-1 symbols documented: 1
- Tier-2 symbols documented: 0
- Files touched: 1

## Verification
- [x] `pnpm --filter @nordcom/cart-shopify typecheck` passes
- [x] `pnpm --filter @nordcom/cart-shopify lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (no logic changes)