### PR TITLE
docs(test-mongo): backfill jsdoc on functions and components

### DIFF
--- a/packages/test-mongo/src/daemon.ts
+++ b/packages/test-mongo/src/daemon.ts
@@ -3,6 +3,19 @@ import { dirname } from 'node:path';
 
 import { startMongo } from './start';
 
+/**
+ * Configuration for the persistent `pnpm dev:mongo` daemon process managed by {@link runDaemon}.
+ *
+ * @example
+ * ```ts
+ * await runDaemon({
+ *     dbPath: resolve('.mongo-dev'),
+ *     port: 27018,
+ *     pidFile: resolve('.mongo-dev', '.pid'),
+ *     uriFile: resolve('.mongo-dev', '.uri'),
+ * });
+ * ```
+ */
 export interface DaemonOptions {
     dbPath: string;
     port: number;

--- a/packages/test-mongo/src/seed/cms.ts
+++ b/packages/test-mongo/src/seed/cms.ts
@@ -8,6 +8,15 @@ import { headerData } from './fixtures/header';
 import { pageFixtures } from './fixtures/pages';
 import { productMetadataFixtures } from './fixtures/product-metadata';
 
+/**
+ * Options for {@link seedCms}. Carries the Mongo `_id` of the Shop that the
+ * newly created Payload Tenant doc will be bound to.
+ *
+ * @example
+ * ```ts
+ * await seedCms(uri, { shopId: String(shop._id) });
+ * ```
+ */
 export interface SeedCmsOptions {
     shopId: string;
 }

--- a/packages/test-mongo/src/seed/shop.ts
+++ b/packages/test-mongo/src/seed/shop.ts
@@ -1,6 +1,16 @@
 import { ShopSchema } from '@nordcom/commerce-db/models/shop';
 import { createConnection, type Schema } from 'mongoose';
 
+/**
+ * Customization knobs for {@link seedShop}. All fields are optional —
+ * defaults produce the canonical `nordcom-demo-shop.com` fixture.
+ *
+ * @example
+ * ```ts
+ * // Pin a different domain for a staging environment:
+ * await seedShop(uri, { domain: 'staging.example.com' });
+ * ```
+ */
 export interface SeedShopOptions {
     domain?: string;
     name?: string;
@@ -9,6 +19,21 @@ export interface SeedShopOptions {
 
 const DEFAULT_DOMAIN = 'nordcom-demo-shop.com';
 
+/**
+ * Creates the canonical demo Shop document via a direct Mongoose connection,
+ * bypassing Payload. Idempotent — skips insert when a document with the same
+ * domain already exists.
+ *
+ * @param uri - MongoDB connection string; also written to `MONGODB_URI` if the
+ *   env var is absent, so downstream Payload bootstraps bind to the same instance.
+ * @param opts - Optional overrides for domain, display name, and raw schema fields.
+ * @returns Resolves once the Shop document is present in the database.
+ * @example
+ * ```ts
+ * const { uri } = await startMongo();
+ * await seedShop(uri);
+ * ```
+ */
 export async function seedShop(uri: string, opts: SeedShopOptions = {}): Promise<void> {
     const domain = opts.domain ?? DEFAULT_DOMAIN;
     const name = opts.name ?? 'Nordcom Demo Shop';

--- a/packages/test-mongo/src/start.ts
+++ b/packages/test-mongo/src/start.ts
@@ -1,5 +1,18 @@
 import { MongoMemoryReplSet } from 'mongodb-memory-server';
 
+/**
+ * Options for {@link startMongo}. Both fields are optional; omitting them
+ * starts an ephemeral in-memory replica-set that is torn down on `stop()`.
+ *
+ * @example
+ * ```ts
+ * // Ephemeral — for unit tests:
+ * const mongo = await startMongo();
+ *
+ * // Persistent — for pnpm dev:
+ * const mongo = await startMongo({ dbPath: '.mongo-dev', port: 27018 });
+ * ```
+ */
 export interface StartMongoOptions {
     /** When set, mongod persists to this directory and survives `.stop()`. */
     dbPath?: string;
@@ -7,6 +20,18 @@ export interface StartMongoOptions {
     port?: number;
 }
 
+/**
+ * Handle returned by {@link startMongo}. Carries the replica-set connection
+ * URI and a `stop()` method that cleanly shuts down the instance, optionally
+ * removing the on-disk data directory.
+ *
+ * @example
+ * ```ts
+ * const { uri, stop } = await startMongo();
+ * // pass uri to mongoose.connect or MongoClient
+ * await stop();
+ * ```
+ */
 export interface StartedMongo {
     uri: string;
     stop: () => Promise<void>;
@@ -27,6 +52,12 @@ const replSetCleanupFlags = new WeakMap<MongoMemoryReplSet, boolean>();
 // fallback for the hard-exit case where async work is no longer possible.
 let handlersInstalled = false;
 
+/**
+ * Registers signal and exit handlers so every `MongoMemoryReplSet` tracked in
+ * `activeReplSets` is stopped when the current process exits — preventing
+ * orphan mongod processes and leftover temp directories when vitest workers
+ * crash or uncaught exceptions bypass `afterAll` hooks.
+ */
 function installShutdownHandlers(): void {
     if (handlersInstalled) return;
     handlersInstalled = true;
@@ -102,6 +133,25 @@ function installShutdownHandlers(): void {
     });
 }
 
+/**
+ * Starts a single-node `MongoMemoryReplSet` backed by WiredTiger and returns
+ * its connection URI plus a `stop()` handle. Pass `dbPath` and `port` to make
+ * the instance persistent across restarts; omit them for an ephemeral test replica-set.
+ *
+ * @param opts - Optional path and port overrides. When `dbPath` is set, the
+ *   data directory is preserved on `stop()` so the next start reuses it.
+ * @returns A `StartedMongo` with the replica-set URI and a graceful stop handle.
+ * @example
+ * ```ts
+ * const { uri, stop } = await startMongo();
+ * try {
+ *     await mongoose.connect(uri);
+ *     // run tests
+ * } finally {
+ *     await stop();
+ * }
+ * ```
+ */
 export async function startMongo(opts: StartMongoOptions = {}): Promise<StartedMongo> {
     installShutdownHandlers();
 


### PR DESCRIPTION
## Summary
Adds JSDoc to all in-scope symbols in `packages/test-mongo` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

## Counts
- Tier-1 symbols documented: 7
- Tier-2 symbols documented: 1
- Files touched: 4

## Verification
- [x] `pnpm --filter @nordcom/commerce-test-mongo typecheck` passes
- [x] `pnpm --filter @nordcom/commerce-test-mongo lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (no logic changes)