### PR TITLE
docs(cart-react): backfill jsdoc on functions and components

### DIFF
--- a/.changeset/jsdoc-cart-react.md
+++ b/.changeset/jsdoc-cart-react.md
@@ -1,0 +1,5 @@
+---
+'@nordcom/cart-react': patch
+---
+
+Backfill JSDoc on public/internal symbols.

--- a/packages/cart/react/src/actions-type.ts
+++ b/packages/cart/react/src/actions-type.ts
@@ -1,33 +1,120 @@
 import type { CartActionResult, CartCapabilities, CartExt, KV, NewCartLine, ProductSnapshot } from '@nordcom/cart-core';
 
+/**
+ * Minimum mutation surface every cart adapter must implement: add, update, and
+ * remove cart lines. Serves as the base constraint for {@link CartActions} and can
+ * be used directly when only the three core mutations are needed.
+ *
+ * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
+ * @example
+ * ```ts
+ * function addItem<TExt extends CartExt>(actions: BaseCartActions<TExt>, line: NewCartLine) {
+ *   return actions.addLine(line);
+ * }
+ * ```
+ */
 export type BaseCartActions<TExt extends CartExt = {}> = {
     addLine(input: NewCartLine & { snapshot?: ProductSnapshot }): Promise<CartActionResult<TExt>>;
     updateLine(input: { lineId: string; quantity: number }): Promise<CartActionResult<TExt>>;
     removeLine(lineId: string): Promise<CartActionResult<TExt>>;
 };
 
+/**
+ * Gift-card mutation methods added to {@link CartActions} when
+ * `CartCapabilities.giftCards` is `true`. Apply or remove a gift card by its
+ * redemption code or server-issued id.
+ *
+ * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
+ * @example
+ * ```ts
+ * const actions = useCartActions<CartCapabilities>();
+ * await actions.applyGiftCard('GIFTCARD123');
+ * ```
+ */
 export type GiftCardActions<TExt extends CartExt = {}> = {
     applyGiftCard(code: string): Promise<CartActionResult<TExt>>;
     removeGiftCard(id: string): Promise<CartActionResult<TExt>>;
 };
 
+/**
+ * Discount-code mutation methods added to {@link CartActions} when
+ * `CartCapabilities.multipleDiscountCodes` is `true`. Apply or remove a
+ * discount code by its string value.
+ *
+ * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
+ * @example
+ * ```ts
+ * const actions = useCartActions<CartCapabilities>();
+ * await actions.applyDiscountCode('SAVE10');
+ * ```
+ */
 export type DiscountActions<TExt extends CartExt = {}> = {
     applyDiscountCode(code: string): Promise<CartActionResult<TExt>>;
     removeDiscountCode(code: string): Promise<CartActionResult<TExt>>;
 };
 
+/**
+ * Cart-note mutation method added to {@link CartActions} when
+ * `CartCapabilities.notes` is `true`. Replaces the entire cart note with a
+ * new string; pass an empty string to clear.
+ *
+ * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
+ * @example
+ * ```ts
+ * const actions = useCartActions<CartCapabilities>();
+ * await actions.updateNote('Please gift wrap this order.');
+ * ```
+ */
 export type NoteActions<TExt extends CartExt = {}> = {
     updateNote(note: string): Promise<CartActionResult<TExt>>;
 };
 
+/**
+ * Cart-attribute mutation method added to {@link CartActions} when
+ * `CartCapabilities.cartAttributes` is `true`. Replaces all cart attributes
+ * atomically with the supplied key-value pairs.
+ *
+ * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
+ * @example
+ * ```ts
+ * const actions = useCartActions<CartCapabilities>();
+ * await actions.updateAttributes([{ key: 'source', value: 'homepage' }]);
+ * ```
+ */
 export type CartAttributeActions<TExt extends CartExt = {}> = {
     updateAttributes(attributes: KV[]): Promise<CartActionResult<TExt>>;
 };
 
+/**
+ * Buyer-identity sync method added to {@link CartActions} when
+ * `CartCapabilities.buyerIdentity` is `true`. Fires when the auth bridge
+ * detects a changed identity so the adapter can associate the cart with
+ * the authenticated user on the server.
+ *
+ * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
+ * @example
+ * ```ts
+ * const actions = useCartActions<CartCapabilities>();
+ * await actions.updateBuyerIdentity();
+ * ```
+ */
 export type BuyerIdentityActions<TExt extends CartExt = {}> = {
     updateBuyerIdentity(): Promise<CartActionResult<TExt>>;
 };
 
+/**
+ * Full action surface for a cart, assembled from {@link BaseCartActions} and
+ * capability-gated mixin types. Pass the same `C` as the kernel snapshot's
+ * `capabilities` to receive a correctly narrowed object from {@link useCartActions}.
+ *
+ * @typeParam C - Capability matrix from the kernel snapshot; drives which optional action groups are included.
+ * @typeParam TExt - Cart extension shape; widens each method's {@link CartActionResult}.
+ * @example
+ * ```ts
+ * const actions = useCartActions<CartCapabilities>();
+ * await actions.addLine({ variantId: 'gid://shopify/ProductVariant/123', quantity: 1 });
+ * ```
+ */
 export type CartActions<C extends CartCapabilities, TExt extends CartExt = {}> = BaseCartActions<TExt> &
     (C['giftCards'] extends true ? GiftCardActions<TExt> : Record<never, never>) &
     (C['multipleDiscountCodes'] extends true ? DiscountActions<TExt> : Record<never, never>) &

--- a/packages/cart/react/src/cart-form.tsx
+++ b/packages/cart/react/src/cart-form.tsx
@@ -5,6 +5,11 @@ import type { ReactNode } from 'react';
 
 type ActionKind = CartMutation['kind'];
 
+/**
+ * Props for {@link CartForm}. Each field maps to a hidden `<input>` the cart
+ * server action reads from `FormData`; only `action`, `formAction`, and
+ * `children` are required for every mutation kind.
+ */
 export interface CartFormProps {
     action: ActionKind;
     variantId?: string;
@@ -17,6 +22,28 @@ export interface CartFormProps {
     children: ReactNode;
 }
 
+/**
+ * Renders a `<form>` that encodes a cart mutation as hidden inputs consumed
+ * by a cart server action. Pass `action` to identify the mutation kind and
+ * supply the relevant optional fields for that kind.
+ *
+ * @param props.action - Cart mutation kind; determines which hidden inputs are rendered.
+ * @param props.variantId - Shopify variant GID; required for `add-line` mutations.
+ * @param props.quantity - Item quantity; used by `add-line` and `update-line`.
+ * @param props.lineId - Cart line id; required for `update-line` and `remove-line`.
+ * @param props.code - Discount or gift-card code for apply/remove operations.
+ * @param props.note - Cart note text for `update-note` mutations.
+ * @param props.snapshot - Inline product snapshot forwarded for optimistic UI on `add-line`.
+ * @param props.formAction - Server action (or handler) called on submit.
+ * @param props.children - Trigger element, typically a submit button.
+ * @returns A `<form>` element with hidden mutation inputs and the provided children.
+ * @example
+ * ```tsx
+ * <CartForm action="add-line" variantId={variantId} quantity={1} formAction={addToCartAction}>
+ *   <button type="submit">Add to cart</button>
+ * </CartForm>
+ * ```
+ */
 export function CartForm(props: CartFormProps) {
     const { action, variantId, quantity, lineId, code, note, snapshot, formAction, children } = props;
     return (

--- a/packages/cart/react/src/devtools-panel.tsx
+++ b/packages/cart/react/src/devtools-panel.tsx
@@ -3,11 +3,33 @@
 import { useContext, useState } from 'react';
 import { CartCapabilitiesContext, CartLinesContext, CartPendingContext, CartStatusContext } from './contexts';
 
+/**
+ * Development-only overlay that renders a toggleable JSON dump of cart
+ * provider state. Returns `null` in production builds so bundlers can
+ * tree-shake the panel completely.
+ *
+ * @returns A fixed-position devtools panel in development; `null` in production.
+ * @example
+ * ```tsx
+ * // Mount alongside <CartProvider> during local development.
+ * <CartProvider {...cartProps}>
+ *   {children}
+ *   <CartDevtools />
+ * </CartProvider>
+ * ```
+ */
 export function CartDevtools() {
     if (process.env.NODE_ENV === 'production') return null;
     return <CartDevtoolsPanel />;
 }
 
+/**
+ * Renders the toggleable cart state inspector. Only instantiated in
+ * development — {@link CartDevtools} gates creation on `NODE_ENV`.
+ *
+ * @returns A fixed-position overlay with a toggle button and a JSON dump of
+ *   cart lines, pending mutations, status, and capabilities.
+ */
 function CartDevtoolsPanel() {
     const [open, setOpen] = useState(false);
     const lines = useContext(CartLinesContext);

--- a/packages/cart/react/src/hydrator-client.tsx
+++ b/packages/cart/react/src/hydrator-client.tsx
@@ -2,6 +2,15 @@
 
 import type { Cart } from '@nordcom/cart-core';
 
+/**
+ * Renders a hidden `<div>` whose data attributes carry the initial cart id and
+ * shop id for the client runtime to read on mount. Kept in a separate Client
+ * Component so {@link CartHydrator} remains a Server Component.
+ *
+ * @param props.initialCart - Cart fetched server-side, or `null` before a cart exists.
+ * @param props.shopId - Tenant shop id written to `data-shop-id`.
+ * @returns A display-none `<div>` with hydration data attributes.
+ */
 export function CartHydratorClient({ initialCart, shopId }: { initialCart: Cart | null; shopId: string }) {
     return (
         <div

--- a/packages/cart/react/src/hydrator.tsx
+++ b/packages/cart/react/src/hydrator.tsx
@@ -1,6 +1,22 @@
 import type { Cart } from '@nordcom/cart-core';
 import { CartHydratorClient } from './hydrator-client';
 
+/**
+ * Server-renderable entry point that seeds the client-side cart hydration
+ * marker. Delegates to a client component that renders a hidden element
+ * carrying the initial cart id and shop id, so the client layer can bootstrap
+ * without an extra network round-trip.
+ *
+ * @param props.initialCart - Cart fetched at render time, or `null` before a
+ *   cart has been created for this visitor.
+ * @param props.shopId - Tenant shop id; scopes the hydration marker to the
+ *   correct cart provider.
+ * @returns A {@link CartHydratorClient} element.
+ * @example
+ * ```tsx
+ * <CartHydrator initialCart={serverCart} shopId={shop.id} />
+ * ```
+ */
 export function CartHydrator({ initialCart, shopId }: { initialCart: Cart | null; shopId: string }) {
     return <CartHydratorClient initialCart={initialCart} shopId={shopId} />;
 }

--- a/packages/cart/react/src/provider.tsx
+++ b/packages/cart/react/src/provider.tsx
@@ -53,6 +53,10 @@ function formatUserError(result: Extract<CartActionResult, { ok: false }>): stri
     return result.message || result.userErrors?.[0]?.message || 'Cart action failed.';
 }
 
+/**
+ * Props for {@link CartProvider}. Wires the kernel snapshot, mutation handler,
+ * and optional optimistic predictors into the React context tree.
+ */
 export interface CartProviderProps<Cfg extends AppCartConfig> {
     kernelSnapshot: KernelSnapshot<Cfg['caps']>;
     submitMutation: SubmitMutation<Cfg['ext']>;
@@ -63,6 +67,38 @@ export interface CartProviderProps<Cfg extends AppCartConfig> {
     children: ReactNode;
 }
 
+/**
+ * Root context provider for the Nordcom cart. Manages the optimistic mutation
+ * queue, projects the cart for all slice hooks, synchronises state with
+ * cross-tab broadcasts, and optionally keeps buyer identity in sync via a
+ * client auth bridge.
+ *
+ * @param props.kernelSnapshot - Adapter capabilities and custom mutation names
+ *   from the server-side kernel; drives the shape of the action surface.
+ * @param props.submitMutation - Server action (or API call) that persists a
+ *   mutation and returns the updated cart.
+ * @param props.initialCart - Cart fetched at render time; seeded into the
+ *   queue on the first commit.
+ * @param props.shopId - Tenant shop id; scopes the BroadcastChannel used for
+ *   cross-tab cart sync.
+ * @param props.predictors - Optional optimistic predictor chains applied before
+ *   the server confirms the mutation.
+ * @param props.clientAuthBridge - Optional React hook bridge that surfaces
+ *   `BuyerIdentity`; triggers `update-buyer-identity` when identity changes.
+ * @param props.children - React subtree that receives cart context.
+ * @returns A stack of React context providers wrapping `children`.
+ * @example
+ * ```tsx
+ * <CartProvider
+ *   kernelSnapshot={kernelSnapshot}
+ *   submitMutation={submitCartMutation}
+ *   initialCart={initialCart}
+ *   shopId={shop.id}
+ * >
+ *   {children}
+ * </CartProvider>
+ * ```
+ */
 export function CartProvider<Cfg extends AppCartConfig>(props: CartProviderProps<Cfg>) {
     const { kernelSnapshot, submitMutation, initialCart, shopId, predictors, clientAuthBridge, children } = props;
     const [state, dispatch] = useReducer(queueReducer, undefined, () => initialQueueState());
@@ -286,6 +322,17 @@ function buyerIdentityKey(b: BuyerIdentity | null): string {
     return JSON.stringify({ e: b.email, p: b.phone, c: b.countryCode, pr: b.provider });
 }
 
+/**
+ * Subscribes to buyer identity changes reported by the auth bridge and
+ * dispatches `update-buyer-identity` mutations whenever the identity key
+ * changes. Renders nothing — used purely for its side-effect.
+ *
+ * @param props.bridge - Client auth bridge whose `useBuyerIdentity` hook is
+ *   called on each render to detect identity changes.
+ * @param props.dispatchMutation - Stable dispatch function from the enclosing
+ *   {@link CartProvider}.
+ * @returns `null`.
+ */
 function BuyerIdentitySync({
     bridge,
     dispatchMutation,

--- a/packages/cart/react/src/types.ts
+++ b/packages/cart/react/src/types.ts
@@ -2,6 +2,20 @@ import type { BuyerIdentity, Cart, CartCapabilities, CartExt, CartLine, CartMuta
 
 export type CartStatus = 'idle' | 'loading' | 'mutating' | 'error';
 
+/**
+ * A single mutation in flight through the optimistic queue — from when it is
+ * first predicted through server confirmation or failure. `status` and `error`
+ * are the fields consumers typically use to show per-line loading spinners or
+ * inline error messages.
+ *
+ * @example
+ * ```ts
+ * const pending = useCartPending(lineId);
+ * if (pending && pending.status === 'in-flight') {
+ *   showSpinner();
+ * }
+ * ```
+ */
 export type PendingMutation = {
     id: string;
     mutation: CartMutation;
@@ -11,33 +25,117 @@ export type PendingMutation = {
     tempLineId?: string;
 };
 
+/**
+ * Minimal React hook contract that exposes buyer identity to {@link CartProvider}
+ * without coupling the cart to a specific auth library. Implement this interface
+ * in the host app and pass it via `CartProviderProps.clientAuthBridge`.
+ *
+ * @example
+ * ```ts
+ * const bridge: ClientAuthBridge = {
+ *   useBuyerIdentity() {
+ *     const { user } = useAuth();
+ *     return { identity: user ? { email: user.email } : null, updatedAt: user?.updatedAt ?? 0 };
+ *   },
+ * };
+ * ```
+ */
 export type ClientAuthBridge = {
     useBuyerIdentity(): { identity: BuyerIdentity | null; updatedAt: number };
 };
 
+/**
+ * Static capabilities snapshot produced by the cart adapter and passed from
+ * the server to the client via `CartProviderProps.kernelSnapshot`. Drives which
+ * optional action groups {@link CartProvider} builds into its action surface.
+ *
+ * @typeParam C - Capability matrix; defaults to the base {@link CartCapabilities} shape.
+ * @example
+ * ```ts
+ * const snapshot: KernelSnapshot = {
+ *   type: 'shopify',
+ *   capabilities: { giftCards: true, notes: false, multipleDiscountCodes: true, cartAttributes: false, buyerIdentity: true },
+ *   customMutationNames: [],
+ * };
+ * ```
+ */
 export type KernelSnapshot<C extends CartCapabilities = CartCapabilities> = {
     type: string;
     capabilities: C;
     customMutationNames: readonly string[];
 };
 
+/**
+ * Contextual snapshot passed to every {@link LinePredictor} and
+ * {@link CartPredictor} invocation. Predictors use these fields to implement
+ * delta-aware projections that compare confirmed versus current projected state.
+ *
+ * @typeParam TExt - Cart extension shape.
+ * @example
+ * ```ts
+ * const myLinePredictor: LinePredictor = (mutation, ctx) => {
+ *   const confirmedCount = ctx.confirmed?.totalQuantity ?? 0;
+ *   return null; // fall through to the next predictor
+ * };
+ * ```
+ */
 export type PredictorCtx<TExt extends CartExt = {}> = {
     confirmed: Cart<TExt> | null;
     projection: Cart<TExt>;
     pending: PendingMutation[];
 };
 
+/**
+ * A function that optimistically projects a single cart line given a pending
+ * mutation. Called once per `add-line` mutation by the projection engine; return
+ * a partial line to override the blank placeholder, or `null` to fall through to
+ * the next predictor in the chain.
+ *
+ * @typeParam TExt - Cart extension shape.
+ * @example
+ * ```ts
+ * const predictors = {
+ *   line: [snapshotPredictor(), cachePredictor({ get: cache.get })],
+ * };
+ * ```
+ */
 export type LinePredictor<TExt extends CartExt = {}> = (
     mutation: CartMutation,
     ctx: PredictorCtx<TExt>,
 ) => Partial<CartLine<TExt['line']>> | null;
 
+/**
+ * A function that projects the entire cart after a pending mutation has been
+ * applied to the lines. Use it to recompute cart-level aggregates — such as
+ * total quantity or subtotal — that depend on the mutated line set.
+ *
+ * @typeParam TExt - Cart extension shape.
+ * @example
+ * ```ts
+ * const predictors = {
+ *   cart: [quantitySumPredictor(), subtotalPredictor()],
+ * };
+ * ```
+ */
 export type CartPredictor<TExt extends CartExt = {}> = (
     projection: Cart<TExt>,
     mutation: CartMutation,
     ctx: PredictorCtx<TExt>,
 ) => Cart<TExt>;
 
+/**
+ * Compile-time pairing of a capability matrix and an extension shape used to
+ * thread consistent type parameters through {@link CartProvider} and its
+ * associated hooks. Define one per app and pass it as the generic argument to
+ * {@link CartProvider} and the action hooks.
+ *
+ * @typeParam C - Capability matrix; must match the kernel snapshot's `capabilities`.
+ * @typeParam E - Cart extension shape for any custom line or cart fields.
+ * @example
+ * ```ts
+ * type MyCartConfig = AppCartConfig<CartCapabilities, { line: { customData: string } }>;
+ * ```
+ */
 export type AppCartConfig<C extends CartCapabilities = CartCapabilities, E extends CartExt = {}> = {
     caps: C;
     ext: E;


### PR DESCRIPTION
## Summary
Adds JSDoc to all in-scope symbols in `packages/cart/react` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

## Counts
- Tier-1 symbols documented: 19
- Tier-2 symbols documented: 3
- Files touched: 7

## Verification
- [x] `pnpm --filter @nordcom/cart-react typecheck` passes
- [x] `pnpm --filter @nordcom/cart-react lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (no logic changes)