### PR TITLE
docs(shopify-html): add @example to ToReactNodesOptions

### DIFF
--- a/packages/shopify-html/src/to-react-nodes.tsx
+++ b/packages/shopify-html/src/to-react-nodes.tsx
@@ -30,6 +30,13 @@ const VOID_ELEMENTS = new Set([
 
 /**
  * Options accepted by {@link toReactNodes} that let callers substitute custom React components for specific HTML tags during conversion.
+ *
+ * @example
+ * ```tsx
+ * toReactNodes(html, {
+ *     components: { a: LinkComponent, img: ResponsiveImage },
+ * });
+ * ```
  */
 export type ToReactNodesOptions = {
     /** Override which component to render for a given tag. */


### PR DESCRIPTION
## Summary
Addresses reviewer blocker on merged PR #1964: `ToReactNodesOptions` is Tier-1 (re-exported from barrel) and requires an `@example`.

## Verification
- [x] typecheck
- [x] lint
- [x] rebased on origin/master
- [x] JSDoc-only diff