### PR TITLE
docs(cart-react): address jsdoc review followups

### DIFF
--- a/.changeset/jsdoc-cart-react-followup.md
+++ b/.changeset/jsdoc-cart-react-followup.md
@@ -1,0 +1,5 @@
+---
+'@nordcom/cart-react': patch
+---
+
+Address jsdoc review followups: missing @example on Props types, capability-mixin example typings, American English.

--- a/packages/cart/react/src/actions-type.ts
+++ b/packages/cart/react/src/actions-type.ts
@@ -27,7 +27,7 @@ export type BaseCartActions<TExt extends CartExt = {}> = {
  * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
  * @example
  * ```ts
- * const actions = useCartActions<CartCapabilities>();
+ * const actions = useCartActions<{ giftCards: true } & CartCapabilities>();
  * await actions.applyGiftCard('GIFTCARD123');
  * ```
  */
@@ -44,7 +44,7 @@ export type GiftCardActions<TExt extends CartExt = {}> = {
  * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
  * @example
  * ```ts
- * const actions = useCartActions<CartCapabilities>();
+ * const actions = useCartActions<{ multipleDiscountCodes: true } & CartCapabilities>();
  * await actions.applyDiscountCode('SAVE10');
  * ```
  */
@@ -61,7 +61,7 @@ export type DiscountActions<TExt extends CartExt = {}> = {
  * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
  * @example
  * ```ts
- * const actions = useCartActions<CartCapabilities>();
+ * const actions = useCartActions<{ notes: true } & CartCapabilities>();
  * await actions.updateNote('Please gift wrap this order.');
  * ```
  */
@@ -77,7 +77,7 @@ export type NoteActions<TExt extends CartExt = {}> = {
  * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
  * @example
  * ```ts
- * const actions = useCartActions<CartCapabilities>();
+ * const actions = useCartActions<{ cartAttributes: true } & CartCapabilities>();
  * await actions.updateAttributes([{ key: 'source', value: 'homepage' }]);
  * ```
  */
@@ -94,7 +94,7 @@ export type CartAttributeActions<TExt extends CartExt = {}> = {
  * @typeParam TExt - Cart extension shape; widens the {@link CartActionResult} each method returns.
  * @example
  * ```ts
- * const actions = useCartActions<CartCapabilities>();
+ * const actions = useCartActions<{ buyerIdentity: true } & CartCapabilities>();
  * await actions.updateBuyerIdentity();
  * ```
  */

--- a/packages/cart/react/src/cart-form.tsx
+++ b/packages/cart/react/src/cart-form.tsx
@@ -9,6 +9,17 @@ type ActionKind = CartMutation['kind'];
  * Props for {@link CartForm}. Each field maps to a hidden `<input>` the cart
  * server action reads from `FormData`; only `action`, `formAction`, and
  * `children` are required for every mutation kind.
+ *
+ * @example
+ * ```tsx
+ * const props: CartFormProps = {
+ *     action: 'add-line',
+ *     variantId: 'gid://shopify/ProductVariant/123',
+ *     quantity: 1,
+ *     formAction: addToCartAction,
+ *     children: <button type="submit">Add to cart</button>,
+ * };
+ * ```
  */
 export interface CartFormProps {
     action: ActionKind;

--- a/packages/cart/react/src/provider.tsx
+++ b/packages/cart/react/src/provider.tsx
@@ -56,6 +56,17 @@ function formatUserError(result: Extract<CartActionResult, { ok: false }>): stri
 /**
  * Props for {@link CartProvider}. Wires the kernel snapshot, mutation handler,
  * and optional optimistic predictors into the React context tree.
+ *
+ * @example
+ * ```tsx
+ * const props: CartProviderProps<AppConfig> = {
+ *     kernelSnapshot,
+ *     submitMutation: submitCartMutation,
+ *     initialCart,
+ *     shopId: shop.id,
+ *     children: <App />,
+ * };
+ * ```
  */
 export interface CartProviderProps<Cfg extends AppCartConfig> {
     kernelSnapshot: KernelSnapshot<Cfg['caps']>;
@@ -69,7 +80,7 @@ export interface CartProviderProps<Cfg extends AppCartConfig> {
 
 /**
  * Root context provider for the Nordcom cart. Manages the optimistic mutation
- * queue, projects the cart for all slice hooks, synchronises state with
+ * queue, projects the cart for all slice hooks, synchronizes state with
  * cross-tab broadcasts, and optionally keeps buyer identity in sync via a
  * client auth bridge.
  *


### PR DESCRIPTION
## Summary
Addresses 2 reviewer blockers and 2 non-blocker observations on merged PR #1967:
1. `CartFormProps`: added missing `@example`.
2. `CartProviderProps`: added missing `@example`.
3. Capability-mixin `@example` blocks (`GiftCardActions`/`DiscountActions`/`NoteActions`/`CartAttributeActions`/`BuyerIdentityActions`) now use a narrowed capability type so the example would actually typecheck.
4. `CartProvider` purpose line: "synchronises" → "synchronizes" per American English rule.

## Verification
- [x] typecheck
- [x] lint
- [x] rebased on origin/master
- [x] JSDoc-only diff
- [x] changeset added