### PR TITLE
docs(cart-next): backfill jsdoc on functions and components

### DIFF
--- a/.changeset/jsdoc-cart-next.md
+++ b/.changeset/jsdoc-cart-next.md
@@ -1,0 +1,5 @@
+---
+'@nordcom/cart-next': patch
+---
+
+Backfill JSDoc on public/internal symbols.

--- a/packages/cart/next/src/cookie-storage.ts
+++ b/packages/cart/next/src/cookie-storage.ts
@@ -6,6 +6,16 @@ const MAX_COOKIE_VALUE_LENGTH = 512;
 const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24 * 180;
 const DEFAULT_COOKIE_NAME = 'nordcom-cart';
 
+/**
+ * Options bag for {@link httpOnlyCookieStorage}. Every field is optional —
+ * the factory applies defaults tuned for a Shopify-style sticky-cart: 180-day
+ * `maxAge`, `sameSite=lax`, `secure` in production, path `/`.
+ *
+ * @example
+ * ```ts
+ * const storage = httpOnlyCookieStorage({ name: 'my-shop-cart', maxAge: 86400 });
+ * ```
+ */
 export interface HttpOnlyCookieStorageOpts {
     name?: string;
     secure?: boolean;

--- a/packages/cart/next/src/event-bridge.ts
+++ b/packages/cart/next/src/event-bridge.ts
@@ -1,10 +1,36 @@
 import type { CartEvent, CartKernel } from '@nordcom/cart-core';
 import { after } from 'next/server';
 
+/**
+ * Per-event handler map passed to {@link nextEventBridge}. Each key is a
+ * {@link CartEvent} discriminant; TypeScript infers the narrowed event payload
+ * for that variant so handlers receive the concrete fields — `cart`, `line`,
+ * `mutation` — without casting. Omit keys for events you don't need to handle.
+ *
+ * @example
+ * ```ts
+ * const handlers: NextEventBridgeHandlers = {
+ *     'cart.line.added': async (event) => {
+ *         await analytics.track('AddToCart', { lineId: event.line.id });
+ *     },
+ * };
+ * ```
+ */
 export type NextEventBridgeHandlers = Partial<{
     [E in CartEvent['type']]: (event: Extract<CartEvent, { type: E }>) => Promise<void> | void;
 }>;
 
+/**
+ * Return type of {@link nextEventBridge}. Exposes a single `onKernel` method
+ * that wires the configured event handlers to a kernel's event bus — call it
+ * once per request lifecycle after constructing the kernel.
+ *
+ * @example
+ * ```ts
+ * const bridge = nextEventBridge({ handlers });
+ * bridge.onKernel(kernel);
+ * ```
+ */
 export interface NextEventBridge {
     /**
      * Subscribes the bridge's configured handlers to a cart kernel's event

--- a/packages/cart/next/src/form-actions.ts
+++ b/packages/cart/next/src/form-actions.ts
@@ -72,6 +72,23 @@ function key(): string {
     return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
+/**
+ * Set of `FormData`-driven server actions returned by {@link createFormCartActions}.
+ * Each method parses and validates a `FormData` payload before delegating to the
+ * typed action surface, enabling native `<form action={…}>` wiring that works
+ * without JavaScript while sharing the same server-side validation path as
+ * progressively enhanced calls.
+ *
+ * @example
+ * ```tsx
+ * const formActions = createFormCartActions({ typed });
+ * // In a Server Component:
+ * <form action={formActions.addLineAction}>
+ *   <input name="variantId" value="gid://shopify/ProductVariant/123" />
+ *   <button type="submit">Add to cart</button>
+ * </form>
+ * ```
+ */
 export interface FormCartActions {
     addLineAction(formData: FormData): Promise<CartActionResult>;
     updateLineAction(formData: FormData): Promise<CartActionResult>;

--- a/packages/cart/next/src/typed-actions.ts
+++ b/packages/cart/next/src/typed-actions.ts
@@ -15,6 +15,19 @@ import { CartUserError } from '@nordcom/cart-core';
 
 import type { CartIdStorage } from './storage';
 
+/**
+ * Pluggable identity bridge for `update-buyer-identity` mutations in
+ * {@link createTypedCartActions}. Wire this to your auth session source so the
+ * cart layer can attach the active buyer without depending on a specific auth
+ * library.
+ *
+ * @example
+ * ```ts
+ * const authBridge: AuthBridge = {
+ *     resolve: async () => ({ email: 'buyer@example.com' }),
+ * };
+ * ```
+ */
 export interface AuthBridge {
     /**
      * Resolves the buyer identity to merge onto `update-buyer-identity`
@@ -27,6 +40,22 @@ export interface AuthBridge {
     resolve(): Promise<BuyerIdentity | null>;
 }
 
+/**
+ * Construction options for {@link createTypedCartActions}. Wires together the
+ * kernel, storage, and request-context factory that the typed action surface
+ * needs; optional `authBridge` and `messageLocalizer` let hosts attach identity
+ * resolution and i18n without coupling the cart layer to a specific auth or
+ * translation library.
+ *
+ * @example
+ * ```ts
+ * const opts: CreateTypedCartActionsOpts<{}, MyShop> = {
+ *     kernel,
+ *     storage: httpOnlyCookieStorage(),
+ *     resolveContext: async ({ idempotencyKey } = {}) => ({ shop, locale, idempotencyKey }),
+ * };
+ * ```
+ */
 export interface CreateTypedCartActionsOpts<TExt extends CartExt, TShop> {
     kernel: CartKernel<TExt, TShop>;
     storage: CartIdStorage;
@@ -35,6 +64,22 @@ export interface CreateTypedCartActionsOpts<TExt extends CartExt, TShop> {
     messageLocalizer?: (reason: CartActionFailureReason, userErrorMessage?: string) => Promise<string>;
 }
 
+/**
+ * Strongly-typed server-action surface built by {@link createTypedCartActions}.
+ * Each method accepts a serializable plain-object args bag (no `FormData`) so
+ * client components can invoke actions through `startTransition` or the
+ * predictive queue without re-parsing form state on the server.
+ *
+ * @example
+ * ```ts
+ * const actions = createTypedCartActions(opts);
+ * const result = await actions.addLine({
+ *     variantId: 'gid://shopify/ProductVariant/123',
+ *     quantity: 1,
+ *     idempotencyKey: crypto.randomUUID(),
+ * });
+ * ```
+ */
 export interface TypedCartActions<TExt extends CartExt = {}> {
     addLine(
         args: NewCartLine & { snapshot?: ProductSnapshot; idempotencyKey: string },


### PR DESCRIPTION
## Summary
Adds JSDoc to all in-scope symbols in `packages/cart/next` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

## Counts
- Tier-1 symbols documented: 7
- Tier-2 symbols documented: 0
- Files touched: 4

## Verification
- [x] `pnpm --filter @nordcom/cart-next typecheck` passes
- [x] `pnpm --filter @nordcom/cart-next lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (no logic changes)