### PR TITLE
docs(cart-next): add missing @example on tier-1 functions

### DIFF
--- a/.changeset/jsdoc-cart-next-followup.md
+++ b/.changeset/jsdoc-cart-next-followup.md
@@ -1,0 +1,5 @@
+---
+'@nordcom/cart-next': patch
+---
+
+Add missing @example blocks on Tier-1 functions per review.

--- a/packages/cart/next/src/cookie-storage.ts
+++ b/packages/cart/next/src/cookie-storage.ts
@@ -45,6 +45,14 @@ export interface HttpOnlyCookieStorageOpts {
  * @param opts.path - Cookie path. Defaults to `/`.
  * @returns A {@link CartIdStorage} implementation suitable for cart-next's
  *   reader, ensurer, and typed-action factories.
+ * @example
+ * ```ts
+ * const actions = createTypedCartActions({
+ *     kernel,
+ *     storage: httpOnlyCookieStorage({ name: 'my-shop-cart' }),
+ *     resolveContext: async ({ idempotencyKey } = {}) => ({ shop, locale, idempotencyKey }),
+ * });
+ * ```
  */
 export function httpOnlyCookieStorage(opts: HttpOnlyCookieStorageOpts = {}): CartIdStorage {
     const name = opts.name ?? DEFAULT_COOKIE_NAME;

--- a/packages/cart/next/src/event-bridge.ts
+++ b/packages/cart/next/src/event-bridge.ts
@@ -58,6 +58,20 @@ export interface NextEventBridge {
  *   handler are ignored — the bridge does not subscribe at all, keeping
  *   the `after()` queue empty.
  * @returns A {@link NextEventBridge} ready to bind to a kernel.
+ * @example
+ * ```ts
+ * const bridge = nextEventBridge({
+ *     handlers: {
+ *         'cart.line.added': async (event) => {
+ *             await analytics.track('AddToCart', { lineId: event.line.id });
+ *         },
+ *         'cart.updated': (event) => {
+ *             cache.invalidate(`cart:${event.cart.id}`);
+ *         },
+ *     },
+ * });
+ * bridge.onKernel(kernel);
+ * ```
  */
 export function nextEventBridge(opts?: { handlers?: NextEventBridgeHandlers }): NextEventBridge {
     const handlers: NextEventBridgeHandlers = opts?.handlers ?? {};

--- a/packages/cart/next/src/form-actions.ts
+++ b/packages/cart/next/src/form-actions.ts
@@ -116,6 +116,17 @@ export interface FormCartActions {
  *
  * @param opts.typed - Typed action surface to dispatch through.
  * @returns A {@link FormCartActions} surface ready for `<form action>` bindings.
+ * @example
+ * ```tsx
+ * const formActions = createFormCartActions({ typed });
+ *
+ * // Wire into a Server Component form — works with or without client JS:
+ * <form action={formActions.addLineAction}>
+ *     <input name="variantId" value="gid://shopify/ProductVariant/123" />
+ *     <input name="quantity" value="1" />
+ *     <button type="submit">Add to cart</button>
+ * </form>
+ * ```
  */
 export function createFormCartActions(opts: { typed: TypedCartActions }): FormCartActions {
     const { typed } = opts;

--- a/packages/cart/next/src/typed-actions.ts
+++ b/packages/cart/next/src/typed-actions.ts
@@ -244,6 +244,19 @@ async function run<TExt extends CartExt, TShop>(
  *   failure reasons + provider messages for the current locale.
  * @returns A {@link TypedCartActions} surface ready to bind as `"use server"`
  *   re-exports.
+ * @example
+ * ```ts
+ * const actions = createTypedCartActions({
+ *     kernel,
+ *     storage: httpOnlyCookieStorage(),
+ *     resolveContext: async ({ idempotencyKey } = {}) => ({ shop, locale, idempotencyKey }),
+ * });
+ * const result = await actions.addLine({
+ *     variantId: 'gid://shopify/ProductVariant/123',
+ *     quantity: 1,
+ *     idempotencyKey: crypto.randomUUID(),
+ * });
+ * ```
  */
 export function createTypedCartActions<TExt extends CartExt = {}, TShop = unknown>(
     opts: CreateTypedCartActionsOpts<TExt, TShop>,


### PR DESCRIPTION
## Summary
Addresses 4 reviewer blockers on merged PR #1990: pre-existing Tier-1 functions in the modified files (`httpOnlyCookieStorage`, `nextEventBridge`, `createFormCartActions`, `createTypedCartActions`) lacked `@example` blocks.

## Verification
- [x] typecheck
- [x] lint
- [x] rebased on origin/master
- [x] JSDoc-only diff
- [x] changeset added