### PR TITLE
docs(storefront-utils): backfill jsdoc on utils/

### DIFF
--- a/apps/storefront/src/utils/checkout.ts
+++ b/apps/storefront/src/utils/checkout.ts
@@ -15,8 +15,12 @@ type CheckoutCart = {
     checkoutUrl: string | null;
 };
 
-// Const hacky workaround for ga4 cross-domain
-// taken from StackOverflow
+/**
+ * Reads the GA4 cross-domain linker `_gl` parameter by submitting a hidden form against the checkout origin.
+ *
+ * @param checkoutOrigin - The full HTTPS URL of the checkout domain used as the form's `action`.
+ * @returns The `_gl` linker string when GA4 has decorated the form, or `null` when the parameter is absent.
+ */
 export const getCrossDomainLinkerParameter = (checkoutOrigin: string) => {
     // create form element, give it an action, make it hidden and prevent the submit event
     const formNode = document.createElement('form');
@@ -61,6 +65,16 @@ export const getCrossDomainLinkerParameter = (checkoutOrigin: string) => {
     }
 };
 
+/**
+ * Fires a `begin_checkout` analytics event and redirects the browser to the Shopify checkout URL, swapping in the configured commerce domain.
+ *
+ * @param options.shop - The current tenant's shop record; must have a Shopify commerce provider.
+ * @param options.locale - The active locale, used to build GA4 item IDs via `productToMerchantsCenterId`.
+ * @param options.cart - The cart to check out; must be non-null, non-empty, and carry a valid HTTPS `checkoutUrl`.
+ * @param options.trackable - Analytics context used to post the `begin_checkout` event before navigation.
+ * @throws {UnknownCommerceProviderError} When the shop's commerce provider is not Shopify.
+ * @throws {InvalidCartError} When the cart is null, empty, or missing a valid HTTPS `checkoutUrl`.
+ */
 export const Checkout = async ({
     shop,
     locale,

--- a/apps/storefront/src/utils/css-variables.tsx
+++ b/apps/storefront/src/utils/css-variables.tsx
@@ -10,7 +10,13 @@ import { Locale } from '@/utils/locale';
 
 extend([a11yPlugin]);
 
-// TODO: Generalize this
+/**
+ * Resolves the primary and secondary branding accent colors for a shop, falling back to the Shopify Brand API when the shop record has no saved accents.
+ *
+ * @param options.domain - The shop's hostname, used to look up the shop when `shop` is omitted.
+ * @param options.shop - Pre-fetched shop record; if provided, skips the DB lookup.
+ * @returns The primary and secondary accent color objects, or `null` when neither shop accents nor Brand API data are available.
+ */
 export const getBrandingColors = async ({ domain, shop }: { domain: string; shop?: OnlineShop }) => {
     try {
         if (!shop) {
@@ -89,6 +95,13 @@ export const getBrandingColors = async ({ domain, shop }: { domain: string; shop
     }
 };
 
+/**
+ * Renders a `<style>` block injecting tenant-specific color CSS custom properties based on the shop's branding accents.
+ *
+ * @param props.domain - The shop's hostname.
+ * @param props.shop - Optional pre-fetched shop record; omit to trigger an automatic DB lookup by domain.
+ * @returns A `<style>` element with resolved color variables, or `null` when branding colors cannot be resolved.
+ */
 const CssVariablesProvider = async ({ domain, shop }: { domain: string; shop?: OnlineShop }) => {
     const branding = await getBrandingColors({ domain, shop });
     if (!branding) {

--- a/apps/storefront/src/utils/deep-equal.ts
+++ b/apps/storefront/src/utils/deep-equal.ts
@@ -1,3 +1,10 @@
+/**
+ * Compares two values for deep equality using JSON serialization.
+ *
+ * @param a - First value.
+ * @param b - Second value.
+ * @returns `true` if both values serialize to identical JSON, otherwise `false`.
+ */
 export function deepEqual<T>(a: T, b: T): boolean {
     try {
         return JSON.stringify(a, null, 0) === JSON.stringify(b, null, 0);

--- a/apps/storefront/src/utils/flags/adapter.ts
+++ b/apps/storefront/src/utils/flags/adapter.ts
@@ -37,6 +37,12 @@ interface PopulatedFlag {
     targeting: Array<{ rule: string; params: Record<string, unknown>; value: unknown }>;
 }
 
+/**
+ * Narrows an unknown DB entry to a flag document shape with `key` and `targeting` fields.
+ *
+ * @param flag - The raw value from a `featureFlags` relation entry.
+ * @returns `true` when `flag` has both `key` and `targeting` properties; rejects null, primitives, and partially-shaped objects.
+ */
 function isPopulated(flag: unknown): flag is PopulatedFlag {
     return typeof flag === 'object' && flag !== null && 'key' in flag && 'targeting' in flag;
 }
@@ -45,6 +51,11 @@ type ShopWithFlags = FlagEntities['shop'] & {
     featureFlags?: Array<{ flag: unknown }>;
 };
 
+/**
+ * Builds the Vercel Flags SDK adapter that evaluates feature flag values against MongoDB-backed targeting rules.
+ *
+ * @returns An `Adapter<T, FlagEntities>` wired to the Nordcom identify function and targeting rule evaluator.
+ */
 export function nordcomFlagAdapter<T>(): Adapter<T, FlagEntities> {
     return {
         identify,

--- a/apps/storefront/src/utils/flags/definitions/accounts-enabled.ts
+++ b/apps/storefront/src/utils/flags/definitions/accounts-enabled.ts
@@ -1,6 +1,11 @@
 import 'server-only';
 import { defineFlag } from '../define';
 
+/**
+ * Flag controlling whether shopper account features (login, order history, address book) are presented.
+ *
+ * @returns `true` when accounts functionality is active for the current request context.
+ */
 export const accountsEnabled = defineFlag<boolean>({
     key: 'accounts-functionality',
     description: 'Enable accounts functionality',

--- a/apps/storefront/src/utils/flags/definitions/product-info-lines.ts
+++ b/apps/storefront/src/utils/flags/definitions/product-info-lines.ts
@@ -1,6 +1,11 @@
 import 'server-only';
 import { defineFlag } from '../define';
 
+/**
+ * Flag controlling whether the info lines section is visible on the product detail page.
+ *
+ * @returns `true` when the info lines block should render.
+ */
 export const productInfoLines = defineFlag<boolean>({
     key: 'product-page-info-lines',
     description: 'Controls if the info lines are visible on the product page',

--- a/apps/storefront/src/utils/flags/definitions/search-filter.ts
+++ b/apps/storefront/src/utils/flags/definitions/search-filter.ts
@@ -1,6 +1,11 @@
 import 'server-only';
 import { defineFlag } from '../define';
 
+/**
+ * Flag controlling whether the search filter panel is visible to shoppers.
+ *
+ * @returns `true` when the filter UI should render.
+ */
 export const searchFilter = defineFlag<boolean>({
     key: 'search-filter',
     description: 'Controls if the search filter is visible',

--- a/apps/storefront/src/utils/flags/entities.ts
+++ b/apps/storefront/src/utils/flags/entities.ts
@@ -17,6 +17,12 @@ export interface FlagEntities {
     visitorId: string;
 }
 
+/**
+ * Extracts a normalized `FlagUser` from a NextAuth session for use in flag targeting predicates.
+ *
+ * @param session - The NextAuth session, or `null` when the shopper is unauthenticated.
+ * @returns A `FlagUser` when the session carries a user with a non-empty `id`, otherwise `null`.
+ */
 export async function mapSessionToUser(session: Session | null): Promise<FlagUser | null> {
     if (!session?.user) return null;
     const u = session.user as Session['user'] & { id?: string; groups?: string[]; customerTags?: string[] };

--- a/apps/storefront/src/utils/flags/evaluate-sync.ts
+++ b/apps/storefront/src/utils/flags/evaluate-sync.ts
@@ -12,6 +12,12 @@ interface PopulatedFlag {
     targeting: Array<{ rule: string; params: Record<string, unknown>; value: unknown }>;
 }
 
+/**
+ * Narrows a featureFlags entry to a resolved flag document with `key` and `targeting` fields.
+ *
+ * @param flag - The raw value from a `featureFlags` array entry.
+ * @returns `true` when the entry is a populated object with `key` and `targeting`; rejects unpopulated refs and primitives.
+ */
 function isPopulated(flag: unknown): flag is PopulatedFlag {
     return typeof flag === 'object' && flag !== null && 'key' in flag && 'targeting' in flag;
 }
@@ -29,6 +35,11 @@ type ShopWithFlags = OnlineShop & {
  *  - Predicates with `requiresUser: true` are skipped.
  *  - Percentage rollouts bucket deterministically (no visitorId).
  *  - Expects `shop` loaded via `Shop.findByDomain(..., { populate: ['featureFlags.flag'] })` — refs are introspected by shape, not by their nominal `FeatureFlagRef` type.
+ *
+ * @param shop - The shop record with `featureFlags` populated (refs resolved to documents).
+ * @param key - The flag key to look up in the shop's feature flag list.
+ * @param defaultValue - Returned when no flag document or matching targeting rule is found.
+ * @returns The resolved flag value.
  */
 export function evaluateShopFlagSync<T>(shop: OnlineShop, key: string, defaultValue: T): T {
     const value = decide<T>(shop as ShopWithFlags, key, defaultValue);
@@ -36,6 +47,14 @@ export function evaluateShopFlagSync<T>(shop: OnlineShop, key: string, defaultVa
     return value;
 }
 
+/**
+ * Walks a shop's populated targeting rules and returns the first matching rule's value, or the flag's `defaultValue`.
+ *
+ * @param shop - The shop record with `featureFlags` populated.
+ * @param key - The flag key to locate.
+ * @param defaultValue - Returned when no flag document exists or no targeting rule matches.
+ * @returns The resolved flag value.
+ */
 // Value-type integrity (T matching stored rule/default value) is enforced by the defineFlag declaration's `defaultValue: T` — not by runtime validation here.
 function decide<T>(shop: ShopWithFlags, key: string, defaultValue: T): T {
     const ref = shop.featureFlags?.find((entry) => isPopulated(entry.flag) && entry.flag.key === key);

--- a/apps/storefront/src/utils/flags/overrides.ts
+++ b/apps/storefront/src/utils/flags/overrides.ts
@@ -6,6 +6,11 @@ import { cache } from 'react';
 
 export type FlagOverrides = Record<string, unknown>;
 
+/**
+ * Reads and decrypts the Vercel Flags toolbar override cookie for the current request.
+ *
+ * @returns The decrypted override map, or `null` when the `vercel-flag-overrides` cookie is absent or `FLAGS_SECRET` is not configured.
+ */
 export const getFlagOverrides = cache(async (): Promise<FlagOverrides | null> => {
     if (!process.env.FLAGS_SECRET) return null;
     const c = await cookies();

--- a/apps/storefront/src/utils/flags/predicates.ts
+++ b/apps/storefront/src/utils/flags/predicates.ts
@@ -24,6 +24,14 @@ interface PredicateEntry {
 const predicates = new Map<string, PredicateEntry>();
 const warnedUnknown = new Set<string>();
 
+/**
+ * Adds a named predicate function to the global registry for use in flag targeting rules.
+ *
+ * @param name - Unique rule name as stored in MongoDB flag targeting entries.
+ * @param fn - Predicate that receives `FlagEntities` and rule-specific `params`; returns `true` to match the rule.
+ * @param metadata - Optional hints for the evaluation layer (e.g., `requiresUser: true` to skip in cached scopes).
+ * @throws {DuplicatePredicateRegistrationError} When a predicate with the same `name` has already been registered.
+ */
 export function registerPredicate<P>(name: string, fn: Predicate<P>, metadata: PredicateMetadata = {}): void {
     if (predicates.has(name)) {
         throw new DuplicatePredicateRegistrationError(name);
@@ -31,10 +39,24 @@ export function registerPredicate<P>(name: string, fn: Predicate<P>, metadata: P
     predicates.set(name, { fn: fn as Predicate, metadata });
 }
 
+/**
+ * Retrieves the metadata associated with a registered predicate.
+ *
+ * @param name - The predicate's registered name.
+ * @returns The `PredicateMetadata` for the predicate, or `undefined` when no predicate is registered under that name.
+ */
 export function getPredicateMetadata(name: string): PredicateMetadata | undefined {
     return predicates.get(name)?.metadata;
 }
 
+/**
+ * Looks up a named predicate in the registry and calls it with the supplied params and entities.
+ *
+ * @param name - The rule name as stored in MongoDB targeting entries.
+ * @param params - Rule-specific configuration passed through to the predicate function.
+ * @param entities - The request context (shop, session, user, visitorId) for the evaluation.
+ * @returns `true` when the predicate matches, `false` when the predicate is unregistered or throws.
+ */
 export function evaluatePredicate(name: string, params: unknown, entities: FlagEntities): boolean {
     const entry = predicates.get(name);
     if (!entry) {

--- a/apps/storefront/src/utils/flags/register-builtin-predicates.ts
+++ b/apps/storefront/src/utils/flags/register-builtin-predicates.ts
@@ -3,6 +3,11 @@ import 'server-only';
 import { hashToBucket } from './hash';
 import { registerPredicate } from './predicates';
 
+/**
+ * Registers the platform's built-in targeting predicates (`shop`, `authenticated`, `group`, `percentage`, `always`) into the global predicate registry.
+ *
+ * @throws {DuplicatePredicateRegistrationError} When called more than once; the caller in `flags/index.ts` swallows this error on re-imports.
+ */
 export function registerBuiltinPredicates(): void {
     registerPredicate<{ shopIds: string[] }>('shop', (entities, params) => params.shopIds.includes(entities.shop.id), {
         requiresUser: false,

--- a/apps/storefront/src/utils/flags/report.ts
+++ b/apps/storefront/src/utils/flags/report.ts
@@ -6,6 +6,11 @@ type ReportFn = (key: string, value: unknown) => void;
 
 let cachedReport: ReportFn | undefined;
 
+/**
+ * Lazily loads and caches the `reportValue` function from the Vercel Flags SDK, falling back to a no-op when the module is unavailable.
+ *
+ * @returns The `reportValue` function from the Flags SDK, or a no-op function if the module cannot be imported.
+ */
 async function loadReportValue(): Promise<ReportFn> {
     if (cachedReport) return cachedReport;
     try {
@@ -17,6 +22,12 @@ async function loadReportValue(): Promise<ReportFn> {
     return cachedReport;
 }
 
+/**
+ * Fires a non-blocking flag value report to the Vercel Flags toolbar; silently drops failures.
+ *
+ * @param key - The flag key being reported.
+ * @param value - The evaluated flag value.
+ */
 export function reportFlagValue(key: string, value: unknown): void {
     void loadReportValue().then((fn) => {
         try {

--- a/apps/storefront/src/utils/format-price.ts
+++ b/apps/storefront/src/utils/format-price.ts
@@ -1,5 +1,12 @@
 export type Money = { amount: string | number; currencyCode: string };
 
+/**
+ * Formats a monetary amount into a locale-specific currency string.
+ *
+ * @param money - Amount and ISO 4217 currency code to format.
+ * @param locale - BCP 47 locale tag passed to `Intl.NumberFormat` for currency display rules.
+ * @returns The formatted price string (e.g., `"$10.00"` or `"10,00 €"`).
+ */
 export function formatPrice(money: Money, locale: string): string {
     const value = typeof money.amount === 'string' ? Number(money.amount) : money.amount;
     return new Intl.NumberFormat(locale, { style: 'currency', currency: money.currencyCode }).format(value);

--- a/apps/storefront/src/utils/image-loader.ts
+++ b/apps/storefront/src/utils/image-loader.ts
@@ -1,5 +1,13 @@
 import type { ImageLoader as ImageLoaderType } from 'next/image';
 
+/**
+ * Next.js image loader that appends `width` and `quality` query parameters to the source URL for image services that accept generic query strings.
+ *
+ * @param src - The original image URL.
+ * @param width - Requested pixel width; omitted from the URL when falsy.
+ * @param quality - Requested image quality (1–100); omitted from the URL when falsy.
+ * @returns The source URL with any non-falsy parameters appended.
+ */
 export const fallbackLoader: ImageLoaderType = ({ src, width, quality }) => {
     const params: string[] = [];
     if (width) {

--- a/apps/storefront/src/utils/locale/weight.ts
+++ b/apps/storefront/src/utils/locale/weight.ts
@@ -4,12 +4,25 @@ import type { Unit } from 'convert-units';
 import ConvertUnits from 'convert-units';
 import type { Locale } from './locale';
 
+/**
+ * Determines whether a locale uses imperial weight measurements (pounds/ounces) rather than metric.
+ *
+ * @param locale - The active locale; only `locale.country` is inspected.
+ * @returns `true` for US, Liberia, and Myanmar locales; also `true` when `locale.country` is absent (safe default for unknown countries).
+ */
 export function usesImperialUnits(locale: Locale): boolean {
     return locale.country
         ? ['us', 'lr', 'mm'].includes(locale.country.toLowerCase()) // United States, Liberia, Myanmar. The rest are metric.
         : true;
 }
 
+/**
+ * Maps a Shopify `WeightUnit` enum value to the equivalent `convert-units` unit symbol.
+ *
+ * @param unit - Shopify weight unit string (e.g., `'GRAMS'`, `'KILOGRAMS'`).
+ * @returns The `convert-units` unit symbol (`'g'`, `'kg'`, `'oz'`, `'lb'`).
+ * @throws {TodoError} When `unit` is not one of the four recognized Shopify weight units.
+ */
 export function weightUnitToUnit(unit: WeightUnit): Unit {
     switch (unit.toLowerCase()) {
         case 'grams':
@@ -25,6 +38,13 @@ export function weightUnitToUnit(unit: WeightUnit): Unit {
         }
     }
 }
+/**
+ * Maps a `convert-units` unit symbol back to the Shopify `WeightUnit` enum value.
+ *
+ * @param unit - A `convert-units` weight symbol (`'g'`, `'kg'`, `'oz'`, `'lb'`).
+ * @returns The corresponding Shopify `WeightUnit` (`'GRAMS'`, `'KILOGRAMS'`, `'OUNCES'`, `'POUNDS'`).
+ * @throws {TodoError} When `unit` is not one of the four recognized symbols.
+ */
 export function unitToWeightUnit(unit: Unit): WeightUnit {
     switch (unit.toLowerCase()) {
         case 'g':
@@ -47,6 +67,13 @@ export type Weight = {
 };
 
 type LocalizeWeightOptions = {};
+/**
+ * Converts a weight to the preferred unit system for the active locale (imperial for US/LR/MM, metric elsewhere).
+ *
+ * @param locale - The active locale, used to determine the unit system via `usesImperialUnits`.
+ * @param weight - The weight to convert.
+ * @returns The weight in the locale-appropriate unit.
+ */
 export function localizeWeight(locale: Locale, weight: Weight, {}: LocalizeWeightOptions = {}): Weight {
     if (usesImperialUnits(locale)) {
         const target = weight.unit === 'GRAMS' || weight.unit === 'OUNCES' ? 'OUNCES' : 'POUNDS';
@@ -63,6 +90,14 @@ export function localizeWeight(locale: Locale, weight: Weight, {}: LocalizeWeigh
     };
 }
 
+/**
+ * Serializes a `Weight` to a compact human-readable string (e.g., `"500g"` or `"1.5kg"`), trimming trailing decimal zeros.
+ *
+ * @param props - The weight to format.
+ * @param props.weight - The numeric weight value.
+ * @param props.unit - The Shopify `WeightUnit` that determines the appended symbol.
+ * @returns A string combining the trimmed numeric value and its unit symbol.
+ */
 export function formatWeight({ weight, unit }: Weight): string {
     let res = weight.toFixed(2);
     if (res.endsWith('.00')) {
@@ -76,6 +111,17 @@ export function formatWeight({ weight, unit }: Weight): string {
 type ConvertWeightOptions = {
     round?: 'WHOLE' | 'FIVES' | false;
 };
+/**
+ * Converts a weight value between Shopify weight units, with optional rounding.
+ *
+ * @param weight - The numeric weight value to convert.
+ * @param from - Source Shopify `WeightUnit`.
+ * @param to - Target Shopify `WeightUnit`.
+ * @param options - Rounding behavior applied after conversion.
+ * @param options.round - `'FIVES'` rounds up to the nearest 0.05 (default), `'WHOLE'` to the nearest 10, `false` returns the raw converted value.
+ * @returns The converted weight, rounded per `options.round`.
+ * @throws {TodoError} When `from` or `to` is not a recognized Shopify `WeightUnit`, or `options.round` is unrecognized.
+ */
 export function convertWeight(
     weight: number,
     from: WeightUnit,

--- a/apps/storefront/src/utils/request-context.ts
+++ b/apps/storefront/src/utils/request-context.ts
@@ -7,6 +7,11 @@ import { Locale } from '@/utils/locale';
 
 export type RequestContext = { shop: OnlineShop; locale: ReturnType<typeof Locale.from> };
 
+/**
+ * Resolves the active shop and locale for the current request from `x-shop-domain` and `x-locale` middleware headers.
+ *
+ * @returns The request context containing `shop` and `locale` when the headers are present and the shop is found, or `null` for unauthenticated or test requests.
+ */
 export const getRequestContext = cache(async (): Promise<RequestContext | null> => {
     try {
         const h = await headers();

--- a/apps/storefront/src/utils/tailwind.ts
+++ b/apps/storefront/src/utils/tailwind.ts
@@ -1,6 +1,12 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+/**
+ * Merges Tailwind CSS class names, resolving conflicts via `tailwind-merge` and handling conditional values via `clsx`.
+ *
+ * @param inputs - Any number of class value expressions (strings, arrays, objects).
+ * @returns The merged class string, or `undefined` when the result is empty.
+ */
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs)) || undefined;
 }

--- a/apps/storefront/src/utils/test/fixtures/cms.ts
+++ b/apps/storefront/src/utils/test/fixtures/cms.ts
@@ -11,6 +11,12 @@ import type {
 
 const isoEpoch = new Date(0).toISOString();
 
+/**
+ * Builds a minimal CMS `Media` fixture for use in tests.
+ *
+ * @param overrides - Partial properties merged onto the base fixture.
+ * @returns A mock `Media` object with sensible defaults.
+ */
 export const mockMedia = (overrides?: Partial<Media>): Media =>
     ({
         id: 'media-mock-1',
@@ -26,6 +32,12 @@ export const mockMedia = (overrides?: Partial<Media>): Media =>
 
 type NavItem = NonNullable<Header['items']>[number];
 
+/**
+ * Builds a minimal CMS Header nav item fixture for use in tests.
+ *
+ * @param overrides - Partial properties merged onto the base nav item fixture.
+ * @returns A mock `NavItem` with a default page link.
+ */
 export const mockNavItem = (overrides?: Partial<NavItem>): NavItem =>
     ({
         id: 'nav-1',
@@ -37,6 +49,12 @@ export const mockNavItem = (overrides?: Partial<NavItem>): NavItem =>
         ...overrides,
     }) as NavItem;
 
+/**
+ * Builds a minimal CMS `Header` fixture for use in tests.
+ *
+ * @param overrides - Partial properties merged onto the base header fixture.
+ * @returns A mock `Header` in `published` status with an empty navigation list.
+ */
 export const mockHeader = (overrides?: Partial<Header>): Header =>
     ({
         id: 'header-mock',
@@ -52,6 +70,12 @@ export const mockHeader = (overrides?: Partial<Header>): Header =>
         ...overrides,
     }) as Header;
 
+/**
+ * Builds a minimal CMS `Footer` fixture for use in tests.
+ *
+ * @param overrides - Partial properties merged onto the base footer fixture.
+ * @returns A mock `Footer` in `published` status with empty sections and social links.
+ */
 export const mockFooter = (overrides?: Partial<Footer>): Footer =>
     ({
         id: 'footer-mock',
@@ -66,6 +90,12 @@ export const mockFooter = (overrides?: Partial<Footer>): Footer =>
         ...overrides,
     }) as Footer;
 
+/**
+ * Builds a minimal CMS `BusinessDatum` fixture for use in tests.
+ *
+ * @param overrides - Partial properties merged onto the base business data fixture.
+ * @returns A mock `BusinessDatum` in `published` status with null contact fields.
+ */
 export const mockBusinessData = (overrides?: Partial<BusinessDatum>): BusinessDatum =>
     ({
         id: 'business-mock',
@@ -81,6 +111,12 @@ export const mockBusinessData = (overrides?: Partial<BusinessDatum>): BusinessDa
         ...overrides,
     }) as BusinessDatum;
 
+/**
+ * Builds a minimal CMS `Page` fixture for use in tests.
+ *
+ * @param overrides - Partial properties merged onto the base page fixture.
+ * @returns A mock `Page` in `published` status with an empty block list.
+ */
 export const mockPage = (overrides?: Partial<Page>): Page =>
     ({
         id: 'page-mock',
@@ -95,6 +131,12 @@ export const mockPage = (overrides?: Partial<Page>): Page =>
         ...overrides,
     }) as Page;
 
+/**
+ * Builds a minimal CMS `Article` fixture for use in tests.
+ *
+ * @param overrides - Partial properties merged onto the base article fixture.
+ * @returns A mock `Article` in `published` status with an empty body and tag list.
+ */
 export const mockArticle = (overrides?: Partial<Article>): Article =>
     ({
         id: 'article-mock',
@@ -114,6 +156,12 @@ export const mockArticle = (overrides?: Partial<Article>): Article =>
         ...overrides,
     }) as Article;
 
+/**
+ * Builds a minimal CMS `ProductMetadatum` fixture for use in tests.
+ *
+ * @param overrides - Partial properties merged onto the base product metadata fixture.
+ * @returns A mock `ProductMetadatum` in `published` status with an empty block list.
+ */
 export const mockProductMetadata = (overrides?: Partial<ProductMetadatum>): ProductMetadatum =>
     ({
         id: 'product-meta-mock',
@@ -128,6 +176,12 @@ export const mockProductMetadata = (overrides?: Partial<ProductMetadatum>): Prod
         ...overrides,
     }) as ProductMetadatum;
 
+/**
+ * Builds a minimal CMS `CollectionMetadatum` fixture for use in tests.
+ *
+ * @param overrides - Partial properties merged onto the base collection metadata fixture.
+ * @returns A mock `CollectionMetadatum` in `published` status with an empty block list.
+ */
 export const mockCollectionMetadata = (overrides?: Partial<CollectionMetadatum>): CollectionMetadatum =>
     ({
         id: 'collection-meta-mock',

--- a/apps/storefront/src/utils/test/fixtures/locale.ts
+++ b/apps/storefront/src/utils/test/fixtures/locale.ts
@@ -1,6 +1,12 @@
 import type { Code } from '@/utils/locale';
 import { Locale } from '@/utils/locale';
 
+/**
+ * Creates a `Locale` object from a BCP 47 locale code for use in tests.
+ *
+ * @param code - The BCP 47 locale code; defaults to `'en-US'`.
+ * @returns The parsed `Locale` instance for the given code.
+ */
 export function mockLocale(code: Code = 'en-US') {
     return Locale.from(code);
 }

--- a/apps/storefront/src/utils/test/fixtures/shop.ts
+++ b/apps/storefront/src/utils/test/fixtures/shop.ts
@@ -2,6 +2,12 @@ import type { OnlineShop } from '@nordcom/commerce-db';
 
 type DeepPartial<T> = { [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K] };
 
+/**
+ * Builds a minimal `OnlineShop` fixture for use in tests, with optional deep-partial overrides.
+ *
+ * @param options.overrides - Deep-partial overrides merged onto the base fixture.
+ * @returns A mock `OnlineShop` with sensible defaults for a Shopify commerce provider.
+ */
 export function mockShop({ overrides }: { overrides?: DeepPartial<OnlineShop> } = {}): OnlineShop {
     const base = {
         id: 'mock-shop-id',

--- a/apps/storefront/src/utils/test/fixtures/shopify/collection.ts
+++ b/apps/storefront/src/utils/test/fixtures/shopify/collection.ts
@@ -1,5 +1,11 @@
 import { mockProduct } from './product';
 
+/**
+ * Builds a minimal Shopify collection fixture for use in tests.
+ *
+ * @param overrides - Properties merged onto the base collection fixture.
+ * @returns A plain object shaped like a Shopify Collection GraphQL response node.
+ */
 export function mockCollection(overrides: Record<string, unknown> = {}) {
     return {
         id: 'gid://shopify/Collection/1',

--- a/apps/storefront/src/utils/test/fixtures/shopify/navigation.ts
+++ b/apps/storefront/src/utils/test/fixtures/shopify/navigation.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds a minimal Shopify navigation menu fixture for use in tests.
+ *
+ * @param overrides - Properties merged onto the base menu fixture.
+ * @returns A plain object shaped like a Shopify Menu GraphQL response node.
+ */
 export function mockNavigation(overrides: Record<string, unknown> = {}) {
     return {
         id: 'gid://shopify/Menu/1',

--- a/apps/storefront/src/utils/test/fixtures/shopify/page.ts
+++ b/apps/storefront/src/utils/test/fixtures/shopify/page.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds a minimal Shopify page fixture for use in tests.
+ *
+ * @param overrides - Properties merged onto the base page fixture.
+ * @returns A plain object shaped like a Shopify Page GraphQL response node.
+ */
 export function mockPage(overrides: Record<string, unknown> = {}) {
     return {
         id: 'gid://shopify/Page/1',

--- a/apps/storefront/src/utils/test/fixtures/shopify/product.ts
+++ b/apps/storefront/src/utils/test/fixtures/shopify/product.ts
@@ -1,3 +1,9 @@
+/**
+ * Builds a minimal Shopify product fixture for use in tests.
+ *
+ * @param overrides - Properties merged onto the base product fixture.
+ * @returns A plain object shaped like a Shopify Product GraphQL response node.
+ */
 export function mockProduct(overrides: Record<string, unknown> = {}) {
     return {
         id: 'gid://shopify/Product/1',

--- a/apps/storefront/src/utils/test/react.tsx
+++ b/apps/storefront/src/utils/test/react.tsx
@@ -8,6 +8,12 @@ import { ShopProvider } from '@/components/shop/provider';
 import { Locale } from '@/utils/locale';
 import { Trackable } from '@/utils/trackable';
 
+/**
+ * Wraps test-rendered components with the minimum provider tree required by the storefront application (shop context + analytics).
+ *
+ * @param props.children - The component tree to wrap.
+ * @returns The wrapped subtree inside `ShopProvider` and `Trackable`.
+ */
 const Providers = ({ children }: { children: ReactNode }) => {
     const shop = {
         id: 'mock-shop-id',
@@ -26,7 +32,20 @@ const Providers = ({ children }: { children: ReactNode }) => {
 };
 
 const customScreen = within(document.body, queries);
+/**
+ * Wraps Testing Library's `within` to scope queries to a specific React element, using the custom query set.
+ *
+ * @param element - The React element to scope queries to.
+ * @returns A Testing Library `within` scope bound to `element`.
+ */
 const customWithin = (element: ReactElement) => within(element as unknown as HTMLElement, queries);
+/**
+ * Renders a React element inside the storefront provider tree and returns Testing Library query utilities.
+ *
+ * @param ui - The element to render.
+ * @param options - Optional Testing Library render options (excluding `queries`).
+ * @returns The Testing Library render result with the wrapped provider tree.
+ */
 const customRender = (ui: Parameters<typeof render>[0], options?: Omit<Parameters<typeof render>[1], 'queries'>) =>
     render(ui, { wrapper: Providers, ...options });
 

--- a/apps/storefront/src/utils/title-to-handle.tsx
+++ b/apps/storefront/src/utils/title-to-handle.tsx
@@ -1,3 +1,9 @@
+/**
+ * Converts a display title into a URL-safe handle by lowercasing, replacing spaces and punctuation with hyphens, and stripping diacritics and special characters.
+ *
+ * @param title - The display title to convert.
+ * @returns A URL-safe handle string.
+ */
 export const TitleToHandle = (title: string) => {
     return (title || '')
         .toLowerCase()

--- a/apps/storefront/src/utils/trackable.tsx
+++ b/apps/storefront/src/utils/trackable.tsx
@@ -437,6 +437,13 @@ export type TrackableProps = {
     children: ReactNode;
     dummy?: boolean;
 };
+/**
+ * Inner analytics provider that wires up Shopify cookies, queues analytics events, and dispatches page-view events on navigation changes.
+ *
+ * @param props.children - The subtree to wrap with the analytics context.
+ * @param props.dummy - When `true`, suppresses all event dispatch regardless of internal-traffic detection.
+ * @returns The `TrackableContext.Provider` wrapping `children`.
+ */
 function TrackableInner({ children, dummy = false }: TrackableProps) {
     const path = usePathname();
     const prevPath = usePrevious(path);
@@ -617,6 +624,13 @@ function TrackableInner({ children, dummy = false }: TrackableProps) {
 // boundary they block the route from prerendering. Render the children with a
 // noop tracking context during prerender; the real provider takes over after
 // hydration without disturbing any descendant `useTrackable` callers.
+/**
+ * Public analytics boundary that renders children with a noop tracking context during prerender and activates the real provider after hydration.
+ *
+ * @param props.children - The subtree to wrap with analytics tracking.
+ * @param props.dummy - When `true`, suppresses all event dispatch; forwarded to `TrackableInner`.
+ * @returns A `Suspense`-wrapped provider tree.
+ */
 export function Trackable({ children, dummy = false }: TrackableProps) {
     return (
         <Suspense
@@ -633,6 +647,7 @@ Trackable.displayName = 'Nordcom.Trackable';
  * Must be a descendant of {@link Trackable}.
  *
  * @returns The trackable context.
+ * @throws {MissingContextProviderError} When called outside of a `Trackable` provider tree.
  */
 export function useTrackable(): TrackableContextValue {
     const context = useContext(TrackableContext);
@@ -643,6 +658,13 @@ export function useTrackable(): TrackableContextValue {
     return context;
 }
 
+/**
+ * Headless component that queues a single analytics event once on mount, using the current pathname as the event path.
+ *
+ * @param props.event - The analytics event type to dispatch.
+ * @param props.data - Additional event data merged with the current pathname.
+ * @returns An empty `Fragment`; this component has no visual output.
+ */
 export function AnalyticsEventTrigger({ event, data }: { event: AnalyticsEventType; data: AnalyticsEventData }) {
     const path = usePathname();
     const { queueEvent } = useTrackable();


### PR DESCRIPTION
Backfills Tier-2 JSDoc blocks on all undocumented functions and React components under `apps/storefront/src/utils/**`.

Every exported and internal named function or React component now carries a 1-line purpose summary plus `@param`, `@returns`, and `@throws` where applicable. Pre-existing incomplete blocks in touched files were brought up to spec (missing `@param`/`@returns`/`@throws` added).