### PR TITLE
docs(storefront-api): backfill jsdoc on api/

### DIFF
--- a/apps/storefront/src/api/_apollo-pool.ts
+++ b/apps/storefront/src/api/_apollo-pool.ts
@@ -13,8 +13,24 @@ const POOL_WARN_THRESHOLD = 1000;
 // revalidate handler.
 const pool = new Map<string, ApolloClient>();
 
+/**
+ * Builds the pool lookup key for a shop + locale pair.
+ *
+ * @param shopId - Unique shop identifier from the `OnlineShop` record.
+ * @param localeCode - BCP-47 locale code, e.g. `"en-US"`.
+ * @returns Composite key string `"<shopId>::<localeCode>"`.
+ */
 const key = (shopId: string, localeCode: string) => `${shopId}::${localeCode}`;
 
+/**
+ * Returns the pooled Apollo client for the given shop + locale, creating one via `factory` on first call.
+ *
+ * @param options - Pool lookup options.
+ * @param options.shop - Shop identity used as part of the pool key.
+ * @param options.locale - Locale used as part of the pool key.
+ * @param options.factory - Called once to create the client when no cached entry exists.
+ * @returns The existing or newly created Apollo client.
+ */
 export function getApolloClient({
     shop,
     locale,
@@ -39,14 +55,28 @@ export function getApolloClient({
     return client;
 }
 
+/**
+ * Removes all Apollo clients for a shop from the pool — called from the webhook revalidate handler.
+ *
+ * @param options - Eviction options.
+ * @param options.shopId - Identifier of the shop whose entries should be removed.
+ */
 export function evictApolloClient({ shopId }: { shopId: string }): void {
     for (const k of pool.keys()) {
         if (k.startsWith(`${shopId}::`)) pool.delete(k);
     }
 }
 
+/**
+ * Clears every entry in the Apollo client pool.
+ */
 export function evictAllApolloClients(): void {
     pool.clear();
 }
 
+/**
+ * Returns the current number of entries in the Apollo client pool.
+ *
+ * @returns Count of active pool entries.
+ */
 export const _poolSize = () => pool.size;

--- a/apps/storefront/src/api/_cms.ts
+++ b/apps/storefront/src/api/_cms.ts
@@ -4,7 +4,12 @@ import type { ShopRef } from '@nordcom/commerce-cms/api';
 import type { Media } from '@nordcom/commerce-cms/types';
 import type { OnlineShop } from '@nordcom/commerce-db';
 
-/** Build the `ShopRef` shape `@nordcom/commerce-cms/api` expects from an OnlineShop. */
+/**
+ * Build the `ShopRef` shape `@nordcom/commerce-cms/api` expects from an OnlineShop.
+ *
+ * @param shop - Tenant record to adapt.
+ * @returns The corresponding `ShopRef` used by CMS API helpers.
+ */
 export const toShopRef = (shop: OnlineShop): ShopRef => ({
     id: shop.id,
     domain: shop.domain,
@@ -16,6 +21,9 @@ export const toShopRef = (shop: OnlineShop): ShopRef => ({
  * `Media` or `null`. With `depth >= 1` on the underlying find, upload relations
  * arrive populated as objects; unset uploads come through as `null`. A bare string
  * id means the depth wasn't enough to populate this hop — treat as no data.
+ *
+ * @param v - Raw Payload upload field value.
+ * @returns The populated `Media` object, or `null` when unpopulated or absent.
  */
 export const populatedMedia = (v: string | Media | null | undefined): Media | null =>
     v && typeof v !== 'string' ? v : null;
@@ -23,6 +31,9 @@ export const populatedMedia = (v: string | Media | null | undefined): Media | nu
 /**
  * Narrow the tenant field (`string | Tenant | null | undefined`) to its id, or null.
  * Used for cache-key purposes and audit logging.
+ *
+ * @param v - Raw tenant field from a Payload document.
+ * @returns The tenant id string, or `null` when absent.
  */
 export const tenantId = (v: string | { id: string } | null | undefined): string | null =>
     typeof v === 'string' ? v : (v?.id ?? null);

--- a/apps/storefront/src/api/_loaders.ts
+++ b/apps/storefront/src/api/_loaders.ts
@@ -17,6 +17,11 @@ import { CollectionApi as _CollectionApi } from './shopify/collection';
 import { ProductApi as _ProductApi } from './shopify/product';
 import { CountriesApi as _CountriesApi, LocaleApi as _LocaleApi, LocalesApi as _LocalesApi } from './store';
 
+/**
+ * Wraps `cacheTag` and swallows the error when called outside a `'use cache'` boundary.
+ *
+ * @param tags - Cache tag strings to register with the current cache entry.
+ */
 const safeCacheTag = (...tags: string[]) => {
     try {
         cacheTag(...tags);
@@ -31,10 +36,35 @@ export const Shop = {
     findAll: cache(RawShop.findAll.bind(RawShop)),
 };
 
+/**
+ * React-cached variant of `CountriesApi`; safe to call multiple times per render without redundant fetches.
+ *
+ * @param args - Arguments forwarded to the underlying `CountriesApi`.
+ * @returns Promise resolving to the list of available countries.
+ */
 export const CountriesApi = cache((args: Parameters<typeof _CountriesApi>[0]) => _CountriesApi(args));
+/**
+ * React-cached variant of `LocaleApi`.
+ *
+ * @param args - Arguments forwarded to the underlying `LocaleApi`.
+ * @returns Promise resolving to the current localization context, or `null` for non-Shopify providers.
+ */
 export const LocaleApi = cache((args: Parameters<typeof _LocaleApi>[0]) => _LocaleApi(args));
+/**
+ * React-cached variant of `LocalesApi`.
+ *
+ * @param args - Arguments forwarded to the underlying `LocalesApi`.
+ * @returns Promise resolving to the list of available locales.
+ * @throws {NoLocalesAvailableError} When the shop has no configured locales.
+ */
 export const LocalesApi = cache((args: Parameters<typeof _LocalesApi>[0]) => _LocalesApi(args));
 
+/**
+ * React-cached variant of `ProductApi` with Shopify product cache tags applied.
+ *
+ * @param args - Arguments forwarded to the underlying `ProductApi`.
+ * @returns Promise resolving to a product result tuple.
+ */
 export const ProductApi = cache((args: Parameters<typeof _ProductApi>[0]) => {
     const shop = args.api.shop();
     const locale = args.api.locale();
@@ -42,6 +72,15 @@ export const ProductApi = cache((args: Parameters<typeof _ProductApi>[0]) => {
     return _ProductApi(args);
 });
 
+/**
+ * React-cached variant of `CollectionApi` with Shopify collection cache tags applied.
+ *
+ * @param args - Arguments forwarded to the underlying `CollectionApi`.
+ * @returns Promise resolving to the collection.
+ * @throws {InvalidHandleError} When the collection handle is invalid.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ * @throws {NotFoundError} When no collection matches the handle.
+ */
 export const CollectionApi = cache((args: Parameters<typeof _CollectionApi>[0]) => {
     const shop = args.api.shop();
     const locale = args.api.locale();
@@ -49,16 +88,64 @@ export const CollectionApi = cache((args: Parameters<typeof _CollectionApi>[0]) 
     return _CollectionApi(args);
 });
 
+/**
+ * React-cached variant of `BlogApi` (Shopify blog).
+ *
+ * @param args - Arguments forwarded to the underlying `BlogApi`.
+ * @returns Promise resolving to a blog result tuple.
+ */
 export const BlogApi = cache((args: Parameters<typeof _BlogApi>[0]) => _BlogApi(args));
+/**
+ * React-cached variant of `ArticleApi` (CMS article overlay).
+ *
+ * @param args - Arguments forwarded to the underlying `ArticleApi`.
+ * @returns Promise resolving to the CMS article, or `null` when none exists.
+ */
 export const ArticleApi = cache((args: Parameters<typeof _ArticleApi>[0]) => _ArticleApi(args));
 
+/**
+ * React-cached variant of `HeaderApi`.
+ *
+ * @param args - Arguments forwarded to the underlying `HeaderApi`.
+ * @returns Promise resolving to the CMS header, or `null` when unseeded.
+ */
 export const HeaderApi = cache((args: Parameters<typeof _HeaderApi>[0]) => _HeaderApi(args));
+/**
+ * React-cached variant of `FooterApi`.
+ *
+ * @param args - Arguments forwarded to the underlying `FooterApi`.
+ * @returns Promise resolving to the CMS footer, or `null` when unseeded.
+ */
 export const FooterApi = cache((args: Parameters<typeof _FooterApi>[0]) => _FooterApi(args));
+/**
+ * React-cached variant of `InfoBarApi`.
+ *
+ * @param args - Arguments forwarded to the underlying `InfoBarApi`.
+ * @returns Promise resolving to the business data, or `null` when unseeded.
+ */
 export const InfoBarApi = cache((args: Parameters<typeof _InfoBarApi>[0]) => _InfoBarApi(args));
+/**
+ * React-cached variant of `ProductMetadataApi`.
+ *
+ * @param args - Arguments forwarded to the underlying `ProductMetadataApi`.
+ * @returns Promise resolving to the product metadata overlay, or `null` when absent.
+ */
 export const ProductMetadataApi = cache((args: Parameters<typeof _ProductMetadataApi>[0]) => _ProductMetadataApi(args));
+/**
+ * React-cached variant of `CollectionMetadataApi`.
+ *
+ * @param args - Arguments forwarded to the underlying `CollectionMetadataApi`.
+ * @returns Promise resolving to the collection metadata overlay, or `null` when absent.
+ */
 export const CollectionMetadataApi = cache((args: Parameters<typeof _CollectionMetadataApi>[0]) =>
     _CollectionMetadataApi(args),
 );
+/**
+ * React-cached variant of `PagesApi` with tenant root cache tags applied.
+ *
+ * @param args - Arguments forwarded to the underlying `PagesApi`.
+ * @returns Promise resolving to the normalized page list result.
+ */
 export const PagesApi = cache((args: Parameters<typeof _PagesApi>[0]) => {
     safeCacheTag(...tenantRootTags(args.shop));
     return _PagesApi(args);

--- a/apps/storefront/src/api/_normalize-payload.ts
+++ b/apps/storefront/src/api/_normalize-payload.ts
@@ -34,6 +34,12 @@ import { cmsDefaultLocales } from '@nordcom/commerce-cms/config';
 // configured locale list is fixed for the process lifetime.
 const LOCALE_SET = new Set<string>(cmsDefaultLocales);
 
+/**
+ * Guards against arrays, `null`, and class instances, accepting only plain JS objects.
+ *
+ * @param v - Value to test.
+ * @returns `true` only when `v` is a non-null, non-array object literal.
+ */
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
     typeof v === 'object' && v !== null && !Array.isArray(v);
 
@@ -43,6 +49,9 @@ const isPlainObject = (v: unknown): v is Record<string, unknown> =>
  * notably `{ id: '<ObjectId>' }` for an unpopulated relation, where 'id'
  * happens to be the ISO 639-1 code for Indonesian and would otherwise
  * false-positive.
+ *
+ * @param v - Plain object to inspect.
+ * @returns `true` when every key in `v` is a configured Payload locale.
  */
 const looksLikeLocaleMap = (v: Record<string, unknown>): boolean => {
     const keys = Object.keys(v);
@@ -53,6 +62,13 @@ const looksLikeLocaleMap = (v: Record<string, unknown>): boolean => {
     return true;
 };
 
+/**
+ * Selects the best matching value from a locale map, falling back through language code then any non-null value.
+ *
+ * @param map - A record keyed by locale codes.
+ * @param preferred - BCP-47 locale code to resolve first.
+ * @returns The value for `preferred`, its language subtag, or any non-null fallback; `null` when all values are absent.
+ */
 const pickLocaleValue = (map: Record<string, unknown>, preferred: string): unknown => {
     if (preferred in map) return map[preferred];
     // BCP-47 `lang-REGION` → ISO 639-1 `lang`. `en-US` doesn't resolve →
@@ -74,13 +90,24 @@ const pickLocaleValue = (map: Record<string, unknown>, preferred: string): unkno
 // is masking the bug.
 let unwrapCount = 0;
 
-/** Test helper: read how many locale maps the last `normalize*` call unwrapped. */
+/**
+ * Test helper: read how many locale maps the last `normalize*` call unwrapped.
+ *
+ * @returns The cumulative unwrap count since the last `__resetLocaleUnwrapCount` call.
+ */
 export const __getLocaleUnwrapCount = (): number => unwrapCount;
 /** Test helper: reset the unwrap counter. */
 export const __resetLocaleUnwrapCount = (): void => {
     unwrapCount = 0;
 };
 
+/**
+ * Recursively walks a Payload document value, unwrapping locale maps at each level.
+ *
+ * @param value - Document fragment to walk.
+ * @param locale - BCP-47 locale code to extract when a locale map is encountered.
+ * @returns The walked value with all locale maps replaced by the selected locale's value.
+ */
 const walk = (value: unknown, locale: string): unknown => {
     if (value == null) return value;
     if (typeof value !== 'object') return value;
@@ -114,5 +141,9 @@ const walk = (value: unknown, locale: string): unknown => {
  * Normalize a Payload document or document fragment by resolving any
  * locale-map shapes to the requested locale. Type-preserving: `T` flows
  * through unchanged on the type level.
+ *
+ * @param value - Document or fragment to normalize.
+ * @param locale - BCP-47 locale code used to pick values from locale maps.
+ * @returns The normalized document with the same shape as the input.
  */
 export const normalizePayloadDoc = <T>(value: T, locale: string): T => walk(value, locale) as T;

--- a/apps/storefront/src/api/article.ts
+++ b/apps/storefront/src/api/article.ts
@@ -17,6 +17,12 @@ export type ArticleApiArgs = { shop: OnlineShop; locale: Locale; slug: string };
  * excerpt/cover, additional tags, and a Lexical body that renders below the
  * Shopify body. Returns `null` when no CMS Article exists for the slug — the
  * Shopify path then renders unchanged.
+ *
+ * @param options - Fetch options.
+ * @param options.shop - Tenant record.
+ * @param options.locale - Request locale for Payload field resolution.
+ * @param options.slug - Article slug to look up.
+ * @returns The normalized CMS article document, or `null` when none exists for the slug.
  */
 export async function ArticleApi({ shop, locale, slug }: ArticleApiArgs): Promise<Article | null> {
     const article = await getArticle({

--- a/apps/storefront/src/api/client.ts
+++ b/apps/storefront/src/api/client.ts
@@ -10,6 +10,13 @@ export type ApiConfig = {
     headers: Record<string, string>;
 };
 
+/**
+ * Creates a new Apollo Client instance configured for the Shopify Storefront API.
+ *
+ * @param config - HTTP endpoint and auth headers for the Storefront API.
+ * @param shop - Tenant record used to set the Next.js revalidation cache tags.
+ * @returns A configured `ApolloClient` instance with caching and error policies set.
+ */
 export const createApolloClient = ({ uri, headers }: ApiConfig, shop: OnlineShop) => {
     return new ApolloClient({
         clientAwareness: {

--- a/apps/storefront/src/api/cms-blog.ts
+++ b/apps/storefront/src/api/cms-blog.ts
@@ -21,6 +21,14 @@ export type BlogApiResult = Awaited<ReturnType<typeof getArticles>>;
  * listings (e.g., a `/news` route). Not consumed by the current `/blogs/...`
  * route — those continue to read Shopify articles directly. See spec section
  * on Routes for the article-overlay design.
+ *
+ * @param options - Fetch options.
+ * @param options.shop - Tenant record.
+ * @param options.locale - Request locale for Payload field resolution.
+ * @param options.page - Page number; defaults to `1`.
+ * @param options.limit - Articles per page; defaults to `12`.
+ * @param options.tag - Optional tag filter.
+ * @returns Normalized Payload article list result.
  */
 export async function BlogApi({ shop, locale, page = 1, limit = 12, tag }: BlogApiArgs): Promise<BlogApiResult> {
     const result = await getArticles({

--- a/apps/storefront/src/api/footer.ts
+++ b/apps/storefront/src/api/footer.ts
@@ -12,6 +12,11 @@ export type FooterApiArgs = { shop: OnlineShop; locale: Locale };
 /**
  * Reads the Payload `Footer` global for this tenant + locale. Mirrors the
  * draft-detection + null-on-missing policy of HeaderApi.
+ *
+ * @param options - Fetch options.
+ * @param options.shop - Tenant record.
+ * @param options.locale - Request locale for Payload field resolution.
+ * @returns The normalized footer document, or `null` when the doc has not been seeded.
  */
 export async function FooterApi({ shop, locale }: FooterApiArgs): Promise<Footer | null> {
     const footer = await getFooter({

--- a/apps/storefront/src/api/header.ts
+++ b/apps/storefront/src/api/header.ts
@@ -14,6 +14,11 @@ export type HeaderApiArgs = { shop: OnlineShop; locale: Locale };
  * mode via `next/headers` so editor previews see autosaved drafts; production
  * renders see published only. Returns `null` when the doc has not been seeded —
  * callers render their minimal fallback chrome in that case.
+ *
+ * @param options - Fetch options.
+ * @param options.shop - Tenant record.
+ * @param options.locale - Request locale for Payload field resolution.
+ * @returns The normalized header document, or `null` when unseeded.
  */
 export async function HeaderApi({ shop, locale }: HeaderApiArgs): Promise<Header | null> {
     const header = await getHeader({

--- a/apps/storefront/src/api/info-bar.ts
+++ b/apps/storefront/src/api/info-bar.ts
@@ -11,6 +11,9 @@ export type InfoBarApiArgs = { shop: OnlineShop; locale: Locale };
  * The info bar is a presentation surface for BusinessData (support contact
  * fields). This helper is a thin alias with a targeted name so call sites
  * read clearly; the underlying fetch is the same as `BusinessDataApi`.
+ *
+ * @param args - Fetch options forwarded to `BusinessDataApi`.
+ * @returns The business data document, or `null` when unseeded.
  */
 export async function InfoBarApi(args: InfoBarApiArgs): Promise<BusinessDatum | null> {
     return BusinessDataApi(args);

--- a/apps/storefront/src/api/metadata.ts
+++ b/apps/storefront/src/api/metadata.ts
@@ -13,6 +13,12 @@ export type MetadataApiArgs = { shop: OnlineShop; locale: Locale; handle: string
  * CMS metadata overlay for a Shopify product handle. The returned doc carries
  * descriptionOverride (Lexical rich text), supplemental render blocks, and
  * SEO field overrides — applied on top of the Shopify product page.
+ *
+ * @param options - Fetch options.
+ * @param options.shop - Tenant record.
+ * @param options.locale - Request locale for Payload field resolution.
+ * @param options.handle - Shopify product handle to look up in the CMS.
+ * @returns The normalized product metadata overlay, or `null` when no entry exists.
  */
 export async function ProductMetadataApi({ shop, locale, handle }: MetadataApiArgs): Promise<ProductMetadatum | null> {
     const meta = await getProductMetadata({
@@ -26,6 +32,12 @@ export async function ProductMetadataApi({ shop, locale, handle }: MetadataApiAr
 /**
  * CMS metadata overlay for a Shopify collection handle. Same overlay
  * semantics as `ProductMetadataApi`.
+ *
+ * @param options - Fetch options.
+ * @param options.shop - Tenant record.
+ * @param options.locale - Request locale for Payload field resolution.
+ * @param options.handle - Shopify collection handle to look up in the CMS.
+ * @returns The normalized collection metadata overlay, or `null` when no entry exists.
  */
 export async function CollectionMetadataApi({
     shop,

--- a/apps/storefront/src/api/page.ts
+++ b/apps/storefront/src/api/page.ts
@@ -6,6 +6,14 @@ import type { Locale } from '@/utils/locale';
 import { toShopRef } from './_cms';
 import { normalizePayloadDoc } from './_normalize-payload';
 
+/**
+ * Fetches all CMS pages for a tenant, up to 1000 results.
+ *
+ * @param options - Fetch options.
+ * @param options.shop - Tenant record.
+ * @param options.locale - Request locale for Payload field resolution.
+ * @returns Normalized Payload page list result.
+ */
 export async function PagesApi({ shop, locale }: { shop: OnlineShop; locale: Locale }) {
     const result = await CmsGetPages({
         shop: toShopRef(shop),
@@ -15,6 +23,15 @@ export async function PagesApi({ shop, locale }: { shop: OnlineShop; locale: Loc
     return normalizePayloadDoc(result, locale.code);
 }
 
+/**
+ * Fetches a single CMS page by its slug for a tenant and locale.
+ *
+ * @param options - Fetch options.
+ * @param options.shop - Tenant record.
+ * @param options.locale - Request locale for Payload field resolution.
+ * @param options.handle - Page slug to look up.
+ * @returns The normalized page document, or `null` when no page exists for the slug.
+ */
 export async function PageApi({ shop, locale, handle }: { shop: OnlineShop; locale: Locale; handle: string }) {
     const page = await CmsGetPage({
         shop: toShopRef(shop),

--- a/apps/storefront/src/api/product.ts
+++ b/apps/storefront/src/api/product.ts
@@ -61,6 +61,13 @@ export type Product = {
 
 export type ProductFilters = SearchResultItemConnection['productFilters'];
 
+/**
+ * Serializes a product's Shopify tracking parameters into a URL query string.
+ *
+ * @param options - Options object.
+ * @param options.product - Product with optional `trackingParameters` field.
+ * @returns A URL-encoded query string, or an empty string when no tracking parameters are present.
+ */
 export const createProductSearchParams = ({
     product: { trackingParameters },
 }: {
@@ -73,6 +80,12 @@ export const createProductSearchParams = ({
     return new URLSearchParams(trackingParameters).toString();
 };
 
+/**
+ * Returns whether a product is tagged vegan and belongs to a category where the claim is meaningful.
+ *
+ * @param product - Product to evaluate.
+ * @returns `true` only for food/clothing/accessories/sports products carrying the `"vegan"` tag.
+ */
 export const isProductVegan = (product: Product): boolean => {
     if (product.tags.length <= 0) {
         return false;
@@ -86,6 +99,12 @@ export const isProductVegan = (product: Product): boolean => {
     return product.tags.map((tag) => tag.toLowerCase().trim()).includes('vegan');
 };
 
+/**
+ * Returns whether a product's type maps to the confectionary category.
+ *
+ * @param product - Product to evaluate.
+ * @returns `true` when `productType` matches a known confectionary keyword such as `"cake"`, `"candy"`, etc.
+ */
 export const isProductConfectionary = (product: Product): boolean => {
     if (!product.productType) {
         return false;
@@ -124,6 +143,12 @@ export type ProductType =
     | 'clothing'
     | 'sports'
     | 'other';
+/**
+ * Resolves a product to one of the canonical platform category tokens.
+ *
+ * @param product - Product to classify.
+ * @returns The matching `ProductType`, or `null` when no category can be determined.
+ */
 export const productType = (product: Product): ProductType | null => {
     if (isProductConfectionary(product)) {
         return 'confectionary';
@@ -134,6 +159,12 @@ export const productType = (product: Product): ProductType | null => {
 
 export type ProductSorting = ProductSortKeys;
 
+/**
+ * Parses the quantity-break metafield into a flat list of price-break tier objects.
+ *
+ * @param quantityBreaks - Raw `quantityBreaks` metafield value from a product variant.
+ * @returns Array of `{ minimumQuantity, value }` tiers, or `null` when absent or unparseable.
+ */
 export function transformQuantityBreaks(quantityBreaks: ProductVariant['quantityBreaks']) {
     if (!quantityBreaks) {
         return null;

--- a/apps/storefront/src/api/shop.ts
+++ b/apps/storefront/src/api/shop.ts
@@ -5,6 +5,12 @@ import { MissingEnvironmentVariableError } from '@nordcom/commerce-errors';
 export type HexColor = `#${string}`;
 export type Color = HexColor;
 
+/**
+ * Reads the `SERVICE_DOMAIN` environment variable.
+ *
+ * @returns The configured service domain string.
+ * @throws {MissingEnvironmentVariableError} When `SERVICE_DOMAIN` is absent from the environment.
+ */
 export function getGlobalServiceDomain() {
     const token = process.env.SERVICE_DOMAIN;
     if (!token) {

--- a/apps/storefront/src/api/shopify.ts
+++ b/apps/storefront/src/api/shopify.ts
@@ -14,6 +14,16 @@ import { ApiBuilder } from '@/utils/abstract-api';
 import { Locale } from '@/utils/locale';
 import { unsafe_cast } from '@/utils/unsafe-cast';
 
+/**
+ * Builds the Shopify Storefront API endpoint and header factory for a tenant.
+ *
+ * @param options - Config options.
+ * @param options.shop - Tenant record; only `domain` is read here.
+ * @param options.buyerIp - Optional buyer IP forwarded to the private-access endpoint for analytics.
+ * @returns An object with `public()` and `private()` factory methods each returning an `ApiConfig`.
+ * @throws {UnknownCommerceProviderError} When the shop's commerce provider is not Shopify.
+ * @throws {ShopMisconfigurationError} When required authentication fields are missing from the provider record.
+ */
 export const ShopifyApiConfig = async ({
     shop: { domain },
     buyerIp,
@@ -77,6 +87,18 @@ type ShopifyApiOptions = {
     buyerIp?: string;
 };
 
+/**
+ * Returns the Apollo-backed Shopify API client for a tenant + locale, pooled for request lifetime.
+ *
+ * @param options - Client options.
+ * @param options.shop - Tenant record.
+ * @param options.locale - Request locale; defaults to `Locale.default`.
+ * @param options.apiConfig - Pre-resolved API config; fetched from Shopify when omitted.
+ * @param options.buyerIp - Forwarded to the private storefront endpoint.
+ * @returns An `AbstractApi`-compatible builder wrapping the pooled Apollo client.
+ * @throws {UnknownCommerceProviderError} When the shop is not a Shopify tenant.
+ * @throws {ShopMisconfigurationError} When Shopify authentication credentials are incomplete.
+ */
 export const ShopifyApolloApiClient = async ({
     shop,
     locale = Locale.default,
@@ -113,6 +135,15 @@ export const ShopifyApolloApiClient = async ({
 
 /**
  * Shopify API client using the fetch API instead of Apollo.
+ *
+ * @param options - Client options.
+ * @param options.shop - Tenant record.
+ * @param options.locale - Request locale; defaults to `Locale.default`.
+ * @param options.apiConfig - Pre-resolved API config; fetched from Shopify when omitted.
+ * @param options.buyerIp - Forwarded to the private storefront endpoint.
+ * @returns An `AbstractApi`-compatible builder wrapping the fetch-based client.
+ * @throws {UnknownCommerceProviderError} When the shop is not a Shopify tenant.
+ * @throws {ShopMisconfigurationError} When Shopify authentication credentials are incomplete.
  */
 export const ShopifyApiClient = async ({ shop, locale = Locale.default, apiConfig, buyerIp }: ShopifyApiOptions) => {
     // TODO: Support public headers too.

--- a/apps/storefront/src/api/shopify/blog.ts
+++ b/apps/storefront/src/api/shopify/blog.ts
@@ -113,6 +113,13 @@ const BLOG_ARTICLE_QUERY = graphql(`
     }
 `);
 
+/**
+ * Fetches the list of all blogs from the Shopify Storefront API.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @returns A result tuple — `[Blog[], undefined]` on success or `[undefined, error]` on failure.
+ */
 export async function BlogsApi({ api }: { api: AbstractApi }): Promise<ApiReturn<Blog[]>> {
     const { data, errors } = await api.query(BLOGS_QUERY, { first: 250 });
 
@@ -129,6 +136,17 @@ export async function BlogsApi({ api }: { api: AbstractApi }): Promise<ApiReturn
     return [unsafe_cast<Blog[]>(flattenConnection(data.blogs)), undefined];
 }
 
+/**
+ * Fetches a single blog and its articles from the Shopify Storefront API.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @param options.handle - Blog handle to fetch; defaults to `"news"`.
+ * @param options.limit - Max articles to include; defaults to `30`.
+ * @param options.sorting - Article sort key; defaults to `"PUBLISHED_AT"`.
+ * @param options.reverseSorting - Whether to reverse the sort order; defaults to `true`.
+ * @returns A result tuple — `[Blog, undefined]` on success or `[undefined, error]` on failure.
+ */
 export async function BlogApi({
     api,
     handle = 'news',
@@ -168,6 +186,15 @@ export async function BlogApi({
     ];
 }
 
+/**
+ * Fetches a single blog article from the Shopify Storefront API.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @param options.blogHandle - Blog handle containing the article; defaults to `"news"`.
+ * @param options.handle - Article handle to fetch.
+ * @returns A result tuple — `[Article, undefined]` on success or `[undefined, error]` on failure.
+ */
 export async function BlogArticleApi({
     api,
     blogHandle = 'news',

--- a/apps/storefront/src/api/shopify/brand.ts
+++ b/apps/storefront/src/api/shopify/brand.ts
@@ -59,6 +59,15 @@ const BRAND_QUERY = graphql(`
     }
 `);
 
+/**
+ * Fetches the Shopify brand assets (logo, colors, cover image, slogan) for the active tenant.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @returns The brand object from the Shopify Storefront API.
+ * @throws {ProviderFetchError} When the Storefront API returns errors.
+ * @throws {NotFoundError} When the shop record is absent from the response.
+ */
 export const BrandApi = async ({ api }: { api: AbstractApi }) => {
     const shop = api.shop();
 

--- a/apps/storefront/src/api/shopify/collection/api.ts
+++ b/apps/storefront/src/api/shopify/collection/api.ts
@@ -29,6 +29,9 @@ type CollectionOptions = ApiOptions &
  * @param options.handle - The handle of the collection to fetch.
  * @param [options.filters] - The filters to apply to the collection.
  * @returns The collection.
+ * @throws {InvalidHandleError} When `handle` fails the validity check.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ * @throws {NotFoundError} When no collection matches the handle.
  */
 export const CollectionApi = async (
     { api, handle, ...props }: CollectionOptions,
@@ -77,6 +80,15 @@ export const CollectionApi = async (
     };
 };
 
+/**
+ * Fetches a lightweight list of all collections with product presence indicators.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @returns Array of collection stubs with `id`, `handle`, and `hasProducts`.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ * @throws {NotFoundError} When the collections field is absent from the response.
+ */
 export const CollectionsApi = async ({
     api,
 }: {

--- a/apps/storefront/src/api/shopify/collection/pagination.ts
+++ b/apps/storefront/src/api/shopify/collection/pagination.ts
@@ -29,6 +29,14 @@ type CollectionsFilters = {
 } & GenericCollectionFilters &
     LimitFilters;
 
+/**
+ * Converts the union-typed `LimitFilters` shape into the `first`/`last` object Shopify GraphQL expects.
+ *
+ * @param filters - Pagination filter; may carry `limit`, `first`, or `last`.
+ * @param defaultLimit - Fallback item count when no limit is specified; defaults to `30`.
+ * @returns An object with `first`, `last`, or both, matching Shopify's cursor-pagination args.
+ * @throws {TodoError} When both `limit` and `first`/`last` are provided simultaneously.
+ */
 // TODO: This should be generic.
 export const extractLimitLikeFilters = (
     filters: LimitFilters,
@@ -85,6 +93,16 @@ type CollectionOptions = ApiOptions &
         | /** @deprecated */ CollectionFilters
     );
 
+/**
+ * Counts all products in a collection across pages and returns per-page cursor positions.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @param options.handle - Collection handle to paginate.
+ * @returns Object with total `pages`, total `products`, and `cursors` array for cursor-based navigation.
+ * @throws {InvalidHandleError} When `handle` fails the validity check.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ */
 export const CollectionPaginationCountApi = async ({
     api,
     handle,
@@ -166,7 +184,13 @@ type CollectionsOptions = ApiOptions &
     );
 
 /**
- * Fetches collections from the Shopify API.
+ * Fetches a paginated slice of collections from the Shopify Storefront API.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @param options.filters - Sorting and cursor constraints for the page request.
+ * @returns Object with `collections` edges and `page_info` cursor metadata.
+ * @throws {ProviderFetchError} When the Shopify query returns errors or page info is absent.
  */
 export const CollectionsPaginationApi = async ({
     api,

--- a/apps/storefront/src/api/shopify/page.ts
+++ b/apps/storefront/src/api/shopify/page.ts
@@ -65,6 +65,12 @@ const PAGES_QUERY = graphql(
 
 type PageFields = ResultOf<typeof PAGE_FIELDS_FRAGMENT>;
 
+/**
+ * Transforms a Shopify page fragment into the normalized `NormalizedShopifyPage` shape.
+ *
+ * @param page - Raw page fragment read from `PAGE_FIELDS_FRAGMENT`.
+ * @returns Normalized page with nullable SEO fields and a guaranteed `onlineStoreUrl`.
+ */
 function normalize(page: PageFields): NormalizedShopifyPage {
     return {
         id: page.id,
@@ -82,6 +88,14 @@ function normalize(page: PageFields): NormalizedShopifyPage {
     };
 }
 
+/**
+ * Fetches a single Shopify page by handle.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @param options.handle - Page handle to fetch.
+ * @returns A result tuple — `[NormalizedShopifyPage, undefined]` on success or `[undefined, error]` on failure.
+ */
 export async function ShopifyPageApi({
     api,
     handle,
@@ -107,6 +121,15 @@ export async function ShopifyPageApi({
     return [normalize(readFragment(PAGE_FIELDS_FRAGMENT, data.page)), undefined];
 }
 
+/**
+ * Recursively fetches all Shopify pages, paginating until exhausted.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @param options.cursor - Pagination cursor for the next page; omitted on the first call.
+ * @param options.pages - Accumulated results from previous pages; omitted on the first call.
+ * @returns A result tuple — `[NormalizedShopifyPage[], undefined]` on success or `[undefined, error]` on failure.
+ */
 export async function ShopifyPagesApi({
     api,
     cursor,

--- a/apps/storefront/src/api/shopify/product/api.ts
+++ b/apps/storefront/src/api/shopify/product/api.ts
@@ -22,6 +22,15 @@ type ProductOptions = ApiOptions &
         fragment?: string;
     };
 
+/**
+ * Fetches a single product from the Shopify Storefront API by handle.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @param options.handle - Product handle to fetch.
+ * @param options.fragment - Optional GraphQL fragment string to override the default product fields.
+ * @returns A result tuple — `[Product, undefined]` on success or `[undefined, error]` on failure.
+ */
 export const ProductApi = async ({ api, handle, fragment }: ProductOptions): Promise<ApiReturn<Product>> => {
     if (!handle) {
         return [undefined, new InvalidHandleError(handle)];
@@ -74,6 +83,18 @@ export const ProductApi = async ({ api, handle, fragment }: ProductOptions): Pro
     }
 };
 
+/**
+ * Fetches a paginated list of products from the Shopify Storefront API.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @param options.limit - Max products per page; defaults to `250`.
+ * @param options.sorting - Product sort key; defaults to `"BEST_SELLING"`.
+ * @param options.cursor - Pagination cursor for the next page.
+ * @returns Object with `products` edges, next `cursor`, and `pagination` flags.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ * @throws {NotFoundError} When no products are returned.
+ */
 export const ProductsApi = async ({
     api,
     limit = 250,

--- a/apps/storefront/src/api/shopify/product/pagination.ts
+++ b/apps/storefront/src/api/shopify/product/pagination.ts
@@ -50,6 +50,15 @@ export type ProductsOptions = ApiOptions & {
     filters: ProductsFilters;
 };
 
+/**
+ * Counts all products matching the filters across pages and returns per-page cursor positions.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @param options.filters - Pagination and sorting constraints.
+ * @returns Object with total `pages`, total `products`, and `cursors` for cursor-based navigation.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ */
 export const ProductsPaginationCountApi = async ({
     api,
     ...props
@@ -120,7 +129,7 @@ export const ProductsPaginationCountApi = async ({
  *
  * @param options - The options.
  * @param options.api - The AbstractApi to use.
- * @param options.filters - The AbstractApi to use.
+ * @param options.filters - Pagination, sorting, and filtering constraints.
  * @param [options.filters.limit=35] - The limit of products to fetch.
  * @param [options.filters.sorting='BEST_SELLING'] - The sorting to use.
  * @param [options.filters.available_for_sale=true] - Whether to include available for sale products, set to `undefined` to disable.
@@ -129,6 +138,8 @@ export const ProductsPaginationCountApi = async ({
  * @param [options.filters.before] - The cursor to use for pagination.
  * @param [options.filters.after] - The cursor to use for pagination.
  * @returns The products.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ * @throws {ApiError} When the Storefront API response is missing page info.
  */
 export const ProductsPaginationApi = async ({
     api,

--- a/apps/storefront/src/api/shopify/recommendation.ts
+++ b/apps/storefront/src/api/shopify/recommendation.ts
@@ -24,6 +24,17 @@ const PRODUCT_RECOMMENDATIONS_QUERY = graphql(
     [PRODUCT_FRAGMENT_MINIMAL],
 );
 
+/**
+ * Fetches related product recommendations from Shopify for a given product GID.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @param options.id - Shopify product GID (e.g. `"gid://shopify/Product/123"`).
+ * @returns Array of recommended products.
+ * @throws {InvalidIDError} When `id` cannot be parsed as a valid GID.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ * @throws {NotFoundError} When no recommendations are returned.
+ */
 // TODO: Migrate to the new recommendations api.
 export const RecommendationApi = async ({ api, id }: { api: AbstractApi; id: string }): Promise<Product[]> => {
     const gid = parseGid(id);

--- a/apps/storefront/src/api/shopify/redirects.ts
+++ b/apps/storefront/src/api/shopify/redirects.ts
@@ -46,8 +46,10 @@ const URL_REDIRECTS_SEARCH_QUERY = graphql(`
  * @param options - The options.
  * @param options.api - The client to use for the query.
  * @param [options.cursor] - The cursor to use for the query.
- * @param [options.redirects]
+ * @param [options.redirects] - Accumulated redirects from previous pages; omitted on the first call.
  * @returns The list of redirects.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ * @throws {NotFoundError} When no redirects exist for the shop.
  */
 export const RedirectsApi = async ({
     api,
@@ -97,7 +99,9 @@ export const RedirectsApi = async ({
  * @param options - The options.
  * @param options.api - The client to use for the query.
  * @param options.path - The path to get the redirect for.
- * @returns The redirect target.
+ * @returns The redirect target, or `null` if none found.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ * @throws {NotFoundError} When no redirects exist for the shop.
  */
 export const RedirectApi = async ({ api, path }: { api: AbstractApi; path: string }): Promise<string | null> => {
     path = path.toLowerCase();

--- a/apps/storefront/src/api/shopify/search.ts
+++ b/apps/storefront/src/api/shopify/search.ts
@@ -46,6 +46,15 @@ export const SEARCH_PRODUCTS_QUERY = graphql(
     [PRODUCT_FRAGMENT_MINIMAL],
 );
 
+/**
+ * Searches Shopify products by query string and returns matching products, filters, and total count.
+ *
+ * @param options - Options object.
+ * @param options.client - Storefront API client.
+ * @param options.query - Search query string; returns an empty result when blank.
+ * @param [options.limit] - Maximum number of results to return; defaults to 75.
+ * @returns Products, product filters, and total result count.
+ */
 export const SearchApi = async ({
     client,
     query,
@@ -94,6 +103,17 @@ export const SearchApi = async ({
     return { products, productFilters, totalCount };
 };
 
+/**
+ * Cached variant of `SearchApi` — resolves shop and locale from their identifiers and delegates to `SearchApi`.
+ *
+ * @param options - Options object.
+ * @param options.shopId - Shop ID for cache tagging.
+ * @param options.shopDomain - Shop domain used to resolve the shop record.
+ * @param options.localeCode - Locale code used to resolve the locale.
+ * @param options.query - Search query string.
+ * @param options.showFilters - Included in the cache key; toggling produces a distinct cache entry.
+ * @returns Products, product filters, and total result count.
+ */
 export async function cachedSearch({
     shopId,
     shopDomain,

--- a/apps/storefront/src/api/shopify/vendor.ts
+++ b/apps/storefront/src/api/shopify/vendor.ts
@@ -54,8 +54,11 @@ type VendorsOptions = { api: AbstractApi };
 /**
  * Get all vendors from Shopify.
  *
- * @param api - The client to use for the query.
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
  * @returns The list of vendors.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ * @throws {NotFoundError} When no products (and therefore no vendors) are found.
  */
 export const VendorsApi = async ({ api }: VendorsOptions): Promise<VendorModel[]> => {
     const shop = api.shop();

--- a/apps/storefront/src/api/store.ts
+++ b/apps/storefront/src/api/store.ts
@@ -75,6 +75,13 @@ const DEFAULT_LOCALE = {
     name: 'United States',
 };
 
+/**
+ * Fetches available countries and their languages from the Shopify Storefront API.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @returns Array of available countries; falls back to a US default when the API returns nothing.
+ */
 export const CountriesApi = async ({ api }: { api: AbstractApi }): Promise<Country[]> => {
     const { data: localData, errors } = await api.query(COUNTRIES_QUERY);
 
@@ -94,6 +101,14 @@ export const CountriesApi = async ({ api }: { api: AbstractApi }): Promise<Count
     );
 };
 
+/**
+ * Derives all supported locales for the shop from the available countries.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @returns Array of supported locales.
+ * @throws {NoLocalesAvailableError} When no locales can be derived from the available countries.
+ */
 export const LocalesApi = async ({ api }: { api: AbstractApi }): Promise<Locale[]> => {
     const countries = await CountriesApi({ api });
 
@@ -114,6 +129,14 @@ export const LocalesApi = async ({ api }: { api: AbstractApi }): Promise<Locale[
     return locales;
 };
 
+/**
+ * Fetches the current localization context (country and language) from the Shopify Storefront API.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @returns Localization object, or `null` when the shop does not use Shopify as its commerce provider.
+ * @throws {ProviderFetchError} When the Shopify query returns errors.
+ */
 export const LocaleApi = async ({ api }: { api: AbstractApi }) => {
     const shop = api.shop();
     if ((shop.commerceProvider.type as string) !== 'shopify') {
@@ -139,6 +162,13 @@ export const LocaleApi = async ({ api }: { api: AbstractApi }) => {
     }
 };
 
+/**
+ * Fetches payment settings for the shop from the Shopify Storefront API.
+ *
+ * @param options - Options object.
+ * @param options.api - Storefront API client.
+ * @returns Payment settings subset, or `null` when the shop does not use Shopify or the query returns no data.
+ */
 export const ShopPaymentSettingsApi = async ({
     api,
 }: {
@@ -176,6 +206,11 @@ export type BusinessDataApiArgs = { shop: OnlineShop; locale: Locale };
  * Reads the Payload `BusinessData` global for this tenant + locale. Returns
  * `null` when the doc has not been seeded — InfoBar / Footer call sites
  * collapse to no-render in that case.
+ *
+ * @param options - Options object.
+ * @param options.shop - Shop record identifying the tenant.
+ * @param options.locale - Locale used for payload normalization.
+ * @returns Normalized business data, or `null` when the doc has not been seeded.
  */
 export const BusinessDataApi = async ({ shop, locale }: BusinessDataApiArgs): Promise<BusinessDatum | null> => {
     const data = await getBusinessData({


### PR DESCRIPTION
Backfills Tier-2 JSDoc (1-line purpose + `@param`/`@returns`/`@throws`) on all exported and internal functions under `apps/storefront/src/api/**`.

- 27 files touched, 497 lines added (all JSDoc, zero runtime changes)
- Every exported arrow constant and named function now carries a block
- Pre-existing incomplete blocks in touched files brought up to spec (missing `@param`, `@returns`, or `@throws` filled in)
- GraphQL document constants and re-export-only index files correctly skipped