### PR TITLE
docs(storefront-other): backfill jsdoc on app/auth/blocks/cart/hooks/middleware/models/root

### DIFF
--- a/apps/storefront/src/app/[domain]/[locale]/[...slug]/static-params.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/[...slug]/static-params.ts
@@ -6,6 +6,14 @@ import { Locale } from '@/utils/locale';
 
 export type CustomPageParams = Promise<{ domain: string; locale: string; slug: string[] }>;
 
+/**
+ * Generates the `slug` segments for all published CMS custom pages under a
+ * given domain/locale pair at build time. Returns a sentinel entry when the
+ * shop has no pages so Cache Components always has at least one path.
+ *
+ * @param params - The already-resolved `domain` and `locale` from the parent segment.
+ * @returns An array of `{ slug }` arrays, one per published CMS page.
+ */
 export async function generateStaticParams({
     params,
 }: {

--- a/apps/storefront/src/app/[domain]/[locale]/_actions/cart.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/_actions/cart.ts
@@ -2,25 +2,152 @@
 
 import { forms, typed } from '@/cart/kernel';
 
+/**
+ * Server Action: adds a line item to the active cart.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const addLine = typed.addLine;
+
+/**
+ * Server Action: updates the quantity of an existing cart line item.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const updateLine = typed.updateLine;
+
+/**
+ * Server Action: removes a line item from the active cart.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const removeLine = typed.removeLine;
+
+/**
+ * Server Action: applies a discount code to the active cart.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const applyDiscountCode = typed.applyDiscountCode;
+
+/**
+ * Server Action: removes a discount code from the active cart.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const removeDiscountCode = typed.removeDiscountCode;
+
+/**
+ * Server Action: applies a gift card to the active cart.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const applyGiftCard = typed.applyGiftCard;
+
+/**
+ * Server Action: removes a gift card from the active cart.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const removeGiftCard = typed.removeGiftCard;
+
+/**
+ * Server Action: updates the order note on the active cart.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const updateNote = typed.updateNote;
+
+/**
+ * Server Action: updates the custom attributes on the active cart.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const updateAttributes = typed.updateAttributes;
+
+/**
+ * Server Action: updates the buyer identity (customer access token, country
+ * code, etc.) on the active cart so the cart is associated with the signed-in
+ * customer.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const updateBuyerIdentity = typed.updateBuyerIdentity;
+
+/**
+ * Server Action: dispatches a raw mutation envelope to the cart kernel,
+ * allowing callers to submit any registered mutation by name.
+ *
+ * @throws {Error} When the mutation fails or the kernel does not recognise the mutation name.
+ */
 export const dispatch = typed.dispatch;
 
+/**
+ * Server Action (form-compatible): adds a line item from a `FormData` submission.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const addLineAction = forms.addLineAction;
+
+/**
+ * Server Action (form-compatible): updates a cart line item quantity from a `FormData` submission.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const updateLineAction = forms.updateLineAction;
+
+/**
+ * Server Action (form-compatible): removes a line item from a `FormData` submission.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const removeLineAction = forms.removeLineAction;
+
+/**
+ * Server Action (form-compatible): applies a discount code from a `FormData` submission.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const applyDiscountCodeAction = forms.applyDiscountCodeAction;
+
+/**
+ * Server Action (form-compatible): removes a discount code from a `FormData` submission.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const removeDiscountCodeAction = forms.removeDiscountCodeAction;
+
+/**
+ * Server Action (form-compatible): applies a gift card from a `FormData` submission.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const applyGiftCardAction = forms.applyGiftCardAction;
+
+/**
+ * Server Action (form-compatible): removes a gift card from a `FormData` submission.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const removeGiftCardAction = forms.removeGiftCardAction;
+
+/**
+ * Server Action (form-compatible): updates the order note from a `FormData` submission.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const updateNoteAction = forms.updateNoteAction;
+
+/**
+ * Server Action (form-compatible): updates cart attributes from a `FormData` submission.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const updateAttributesAction = forms.updateAttributesAction;
+
+/**
+ * Server Action (form-compatible): updates buyer identity from a `FormData` submission.
+ *
+ * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ */
 export const updateBuyerIdentityAction = forms.updateBuyerIdentityAction;

--- a/apps/storefront/src/app/[domain]/[locale]/blogs/[blog]/[handle]/static-params.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/blogs/[blog]/[handle]/static-params.ts
@@ -9,6 +9,15 @@ import { Locale } from '@/utils/locale';
 
 export type ArticlePageParams = Promise<{ domain: string; locale: string; blog: string; handle: string }>;
 
+/**
+ * Generates the `handle` segments for all articles in a given blog under a
+ * domain/locale pair at build time. Returns a sentinel entry for missing or
+ * invalid blogs so Cache Components always has at least one path.
+ *
+ * @param params - The already-resolved `domain`, `locale`, and `blog` handle from the parent segments.
+ * @returns An array of `{ handle }` objects, one per article in the blog.
+ * @throws When a non-404 Shopify error is encountered during article enumeration.
+ */
 export async function generateStaticParams({
     params,
 }: {

--- a/apps/storefront/src/app/[domain]/[locale]/blogs/[blog]/static-params.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/blogs/[blog]/static-params.ts
@@ -10,6 +10,15 @@ import { Locale } from '@/utils/locale';
 
 export type BlogPageParams = Promise<{ domain: string; locale: string; blog: string }>;
 
+/**
+ * Generates the `blog` handle segments for all blogs in a shop under a given
+ * domain/locale pair at build time. Returns a sentinel entry when the shop
+ * has no blogs so Cache Components always has at least one path.
+ *
+ * @param params - The already-resolved `domain` and `locale` from the parent segment.
+ * @returns An array of `{ blog }` objects, one per blog in the shop.
+ * @throws When a non-404 Shopify error is encountered during blog enumeration.
+ */
 export async function generateStaticParams({
     params,
 }: {

--- a/apps/storefront/src/app/[domain]/[locale]/cart/cart-content.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/cart/cart-content.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/utils/tailwind';
 import styles from './cart-content.module.css';
 import { CartSidebar } from './cart-sidebar';
 
+/** Props for the `CartContent` server component. */
 export type CartContentProps = {
     shop: OnlineShop;
     locale: Locale;
@@ -18,6 +19,17 @@ export type CartContentProps = {
     paymentMethods?: ReactNode;
 };
 
+/**
+ * Server component that composes the cart page layout: a cart lines list on
+ * the left and an order summary sidebar on the right. Both sections use
+ * `Suspense` so the page can stream without blocking on cart data.
+ *
+ * @param locale - The active locale, forwarded to `CartSidebar` for pricing display.
+ * @param i18n - The locale dictionary for translated labels.
+ * @param header - A slot for the cart page heading rendered above the line items.
+ * @param paymentMethods - Optional slot for accepted payment method badges in the sidebar.
+ * @returns The cart page content layout.
+ */
 export default async function CartContent({ locale, i18n, header, paymentMethods = null }: CartContentProps) {
     return (
         <PageContent className={styles.container}>

--- a/apps/storefront/src/app/[domain]/[locale]/cart/cart-sidebar.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/cart/cart-sidebar.tsx
@@ -12,11 +12,24 @@ import type { Locale, LocaleDictionary } from '@/utils/locale';
 import { cn } from '@/utils/tailwind';
 import { useTrackable } from '@/utils/trackable';
 
+/** Props for the `CartSidebar` client component. */
 export type CartSidebarProps = {
     locale: Locale;
     i18n: LocaleDictionary;
     paymentMethods?: ReactNode;
 } & HTMLProps<HTMLDivElement>;
+/**
+ * Client component rendering the cart order summary sidebar with a checkout
+ * button. Guards checkout by refusing to proceed when the cart is still
+ * loading or when the last mutation left an unresolved error.
+ *
+ * @param i18n - The locale dictionary for translated labels.
+ * @param locale - The active locale forwarded to the checkout utility.
+ * @param className - Additional class name applied to the outer `aside` element.
+ * @param children - Optional content rendered inside the cart summary.
+ * @param paymentMethods - Optional payment method badges rendered below the checkout button.
+ * @returns The cart summary aside element.
+ */
 export const CartSidebar = ({ i18n, locale, className, children, paymentMethods, ...props }: CartSidebarProps) => {
     const { shop } = useShop();
 

--- a/apps/storefront/src/app/[domain]/[locale]/collections/[handle]/collection-content.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/collections/[handle]/collection-content.tsx
@@ -13,6 +13,18 @@ type SearchParams = {
     page?: string;
 };
 
+/**
+ * Server component rendering a paginated product grid for a collection.
+ * Validates the page number against the known page count and calls
+ * `notFound()` for out-of-range or non-numeric page params.
+ *
+ * @param shop - The tenant shop, forwarded to `CollectionBlock` for API calls.
+ * @param locale - The active locale forwarded to `CollectionBlock`.
+ * @param handle - The Shopify collection handle to render.
+ * @param searchParams - Optional query params; `page` controls the current page.
+ * @param pagesInfo - Pre-fetched cursor array and total page count from the parent.
+ * @returns The paginated collection product grid wrapped in `Suspense`.
+ */
 export async function CollectionContent({
     shop,
     locale,

--- a/apps/storefront/src/app/[domain]/[locale]/collections/[handle]/static-params.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/collections/[handle]/static-params.ts
@@ -8,6 +8,15 @@ import { Locale } from '@/utils/locale';
 
 export type CollectionPageParams = Promise<{ domain: string; locale: string; handle: string }>;
 
+/**
+ * Generates the `handle` segments for all collections in a shop under a given
+ * domain/locale pair at build time. Returns a sentinel entry when the catalog
+ * is empty so Cache Components always has at least one path.
+ *
+ * @param params - The already-resolved `domain` and `locale` from the parent segment.
+ * @returns An array of `{ handle }` objects, one per collection.
+ * @throws When a non-404 Shopify error is encountered during collection enumeration.
+ */
 export async function generateStaticParams({
     params,
 }: {

--- a/apps/storefront/src/app/[domain]/[locale]/countries/locale-selector.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/countries/locale-selector.tsx
@@ -15,6 +15,16 @@ type LocaleSelectorProps = {
     countries: Country[];
     locale: Locale;
 };
+/**
+ * Client component that renders a grid of locale links for the countries page.
+ * Clicking a locale link updates a hidden input and programmatically submits
+ * the parent form so the locale change can be handled server-side without a
+ * full page reload.
+ *
+ * @param countries - The list of Shopify countries with available languages.
+ * @param locale - The currently active locale, used to highlight the active entry.
+ * @returns The locale selector grid element.
+ */
 export default function LocaleSelector({ countries = [], locale }: LocaleSelectorProps) {
     const { shop } = useShop();
     const localeRef = useRef<HTMLInputElement>(null);

--- a/apps/storefront/src/app/[domain]/[locale]/metadata.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/metadata.ts
@@ -11,6 +11,15 @@ import { Locale } from '@/utils/locale';
 import { unsafe_cast } from '@/utils/unsafe-cast';
 import type { LayoutParams } from './layout';
 
+/**
+ * Generates the base `Metadata` for the tenant layout — title template,
+ * icons, robots directives, and OpenGraph site name — cached at the `max`
+ * lifetime so it doesn't re-run on every request. Calls `notFound()` for
+ * unknown domains or locales so Next.js renders the nearest not-found UI.
+ *
+ * @param params - The layout route params containing `domain` and `locale`.
+ * @returns The `Metadata` object for the tenant layout.
+ */
 export async function generateMetadata({ params }: { params: LayoutParams }): Promise<Metadata> {
     'use cache';
     cacheLife('max');

--- a/apps/storefront/src/app/[domain]/[locale]/products/[handle]/product-content.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/products/[handle]/product-content.tsx
@@ -15,10 +15,21 @@ import { safeParseFloat } from '@/utils/pricing';
 import { cn } from '@/utils/tailwind';
 import { unsafe_cast } from '@/utils/unsafe-cast';
 
+/** Props for the `ProductContent` client component. */
 export type ProductContentProps = {
     product: Product;
     i18n: LocaleDictionary;
 };
+/**
+ * Client component that wires the Hydrogen `ProductProvider` and
+ * `QuantityProvider` around the product actions UI. Reads the `variant`
+ * search param to pre-select a specific variant; falls back to the first
+ * available variant when absent.
+ *
+ * @param product - The product data including variants and availability.
+ * @param i18n - The locale dictionary for translated labels in the actions UI.
+ * @returns The product actions section with variant selection and add-to-cart.
+ */
 export function ProductContent({ product, i18n }: ProductContentProps) {
     const searchParams = useSearchParams();
     const initialVariantId = useMemo(
@@ -44,11 +55,22 @@ export function ProductContent({ product, i18n }: ProductContentProps) {
     );
 }
 
+/** Props for the `ProductSavings` client component. */
 export type ProductSavingsProps = {
     product: Product;
     i18n: LocaleDictionary;
     className?: string;
 };
+/**
+ * Client component that displays a sale savings badge for the currently
+ * selected variant. Returns `null` when the product is unavailable, the
+ * variant has no compare-at price, or the computed savings are negative.
+ *
+ * @param i18n - The locale dictionary for translated savings copy.
+ * @param product - The product data used to locate the active variant and pricing.
+ * @param className - Optional extra class names applied to the badge element.
+ * @returns The savings badge, or `null` when there are no savings to display.
+ */
 export function ProductSavings({ i18n, product, className }: ProductSavingsProps) {
     const searchParams = useSearchParams();
     const variant = useMemo(

--- a/apps/storefront/src/app/[domain]/[locale]/products/[handle]/product-details.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/products/[handle]/product-details.tsx
@@ -17,11 +17,22 @@ const LABEL_STYLES = 'leading-none text-base';
 const CONTENT_STYLES =
     'flex items-center justify-center rounded-lg bg-gray-100 p-1 px-2 text-sm font-semibold leading-tight hyphens-auto h-min gap-1';
 
+/** Props for the `ProductIngredients` server component. */
 export type ProductIngredientsProps = {
     locale: Locale;
     data: Product;
     className?: string;
 };
+/**
+ * Server component rendering the product ingredients card when the product
+ * has an `ingredients` Shopify metafield. Returns `null` when the metafield is
+ * absent or cannot be parsed.
+ *
+ * @param locale - The active locale, used to fetch the i18n dictionary.
+ * @param data - The product data containing the `ingredients` metafield.
+ * @param className - Optional extra class names applied to the card element.
+ * @returns The ingredients card, or `null` when no ingredients data is available.
+ */
 export async function ProductIngredients({ locale, data: product, className = '' }: ProductIngredientsProps) {
     const i18n = await getDictionary(locale);
     const { t } = getTranslations('product', i18n);
@@ -44,10 +55,19 @@ export async function ProductIngredients({ locale, data: product, className = ''
     );
 }
 
+/** Props for the `ProductOriginalName` server component. */
 export type ProductOriginalNameProps = {
     locale: Locale;
     data: Product;
 };
+/**
+ * Server component rendering the product's original/trade name from the
+ * `originalName` Shopify metafield in italics. Returns `null` when the
+ * metafield is absent or cannot be parsed.
+ *
+ * @param data - The product data containing the `originalName` metafield.
+ * @returns The original name paragraph element, or `null` when unavailable.
+ */
 export async function ProductOriginalName({ data: product }: ProductOriginalNameProps) {
     //const i18n = await getDictionary(locale);
     //const { t } = getTranslations('product', i18n);
@@ -65,10 +85,20 @@ export async function ProductOriginalName({ data: product }: ProductOriginalName
     return <p className="font-medium text-base italic">&ldquo;{parsedName}&rdquo;</p>;
 }
 
+/** Props for the `ProductDetails` server component. */
 export type ProductDetailsProps = {
     locale: Locale;
     data: Product;
 };
+/**
+ * Server component rendering confectionary-specific product details: flavor
+ * attributes and per-variant SKU/barcode cards, plus the ingredients section
+ * via `ProductIngredients`. Returns `null` for non-confectionary products.
+ *
+ * @param locale - The active locale, forwarded to `ProductIngredients` for dictionary lookup.
+ * @param data - The product data; must satisfy `isProductConfectionary` to render.
+ * @returns The details section, or `null` for non-confectionary products.
+ */
 export async function ProductDetails({ locale, data: product }: ProductDetailsProps) {
     const i18n = await getDictionary(locale);
     const { t } = getTranslations('product', i18n);

--- a/apps/storefront/src/app/[domain]/[locale]/products/[handle]/static-params.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/products/[handle]/static-params.ts
@@ -10,6 +10,17 @@ import { Locale } from '@/utils/locale';
 
 export type ProductPageParams = Promise<{ domain: string; locale: string; handle: string }>;
 
+/**
+ * Generates the `handle` segments for products in a shop under a given
+ * domain/locale pair at build time. Fetches a limited product set to keep
+ * build-time rendering tractable; the rest are served via ISR. Returns a
+ * sentinel entry when the catalog is empty so Cache Components always has
+ * at least one path.
+ *
+ * @param params - The already-resolved `domain` and `locale` from the parent segment.
+ * @returns An array of `{ handle }` objects for pre-rendered products.
+ * @throws When a non-404 Shopify error is encountered during product enumeration.
+ */
 export async function generateStaticParams({
     params,
 }: {

--- a/apps/storefront/src/app/[domain]/[locale]/products/products-content.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/products/products-content.tsx
@@ -17,11 +17,22 @@ type SearchParams = {
     sorting?: string;
 };
 
+/** Props for the `ProductsContent` server component. */
 export type ProductsContentContentProps = {
     domain: string;
     locale: Locale;
     searchParams?: SearchParams;
 };
+/**
+ * Server component that fetches and renders a paginated, filterable product
+ * grid for the all-products page. Calls `notFound()` when the requested page
+ * number is out of range.
+ *
+ * @param domain - The tenant shop domain used to resolve the shop record.
+ * @param locale - The active locale forwarded to Shopify API calls and product cards.
+ * @param searchParams - Optional query params; `page`, `vendor`, and `sorting` control the listing.
+ * @returns The product grid with pagination controls above and below.
+ */
 export default async function ProductsContent({ domain, locale, searchParams = {} }: ProductsContentContentProps) {
     const shop = await Shop.findByDomain(domain);
     const api = await ShopifyApolloApiClient({ shop, locale });

--- a/apps/storefront/src/app/[domain]/[locale]/search/search-content-gate.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/search/search-content-gate.tsx
@@ -8,6 +8,7 @@ import SearchProductCard from '@/components/products/search-product-card';
 import type { Locale, LocaleDictionary } from '@/utils/locale';
 import SearchContent from './search-content';
 
+/** Props for the `SearchContentGate` server component. */
 export type SearchContentGateProps = {
     shop: OnlineShop;
     locale: Locale;
@@ -16,6 +17,20 @@ export type SearchContentGateProps = {
     data: { products?: Product[]; productFilters?: ProductFilters; totalCount?: number };
 };
 
+/**
+ * Server component that bridges the search page's server-fetched product data
+ * into the client `SearchContent` component. Constructs pre-rendered product
+ * card nodes (wrapped in `Suspense`) and skeleton placeholders, then passes
+ * both to `SearchContent` so the client component can swap between them during
+ * pending transitions without making additional server requests.
+ *
+ * @param shop - The tenant shop, forwarded to each `SearchProductCard`.
+ * @param locale - The active locale forwarded to product cards and `SearchContent`.
+ * @param i18n - The locale dictionary forwarded to `SearchContent`.
+ * @param showFilters - Whether `SearchContent` should render filter controls.
+ * @param data - Server-fetched search results containing products, filters, and total count.
+ * @returns The `SearchContent` client component with pre-rendered product and skeleton cards.
+ */
 export default function SearchContentGate({ shop, locale, i18n, showFilters, data }: SearchContentGateProps) {
     const { products = [], productFilters = [], totalCount } = data;
 
@@ -42,6 +57,12 @@ export default function SearchContentGate({ shop, locale, i18n, showFilters, dat
     );
 }
 
+/**
+ * Skeleton placeholder for the search results list, rendering six horizontal
+ * card placeholders while the real results are loading.
+ *
+ * @returns The skeleton results list element.
+ */
 SearchContentGate.Skeleton = function SearchContentGateSkeleton() {
     return (
         <div className="flex flex-col gap-0">

--- a/apps/storefront/src/app/[domain]/[locale]/search/search-content.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/search/search-content.tsx
@@ -18,6 +18,19 @@ type SearchBarProps = {
     onSearch: (q: string) => void;
     disabled?: boolean;
 } & HTMLProps<HTMLDivElement>;
+/**
+ * Client search input with an inline submit button. Fires the `onSearch`
+ * callback on Enter, blur (when non-empty), or button click — intentionally
+ * not on every keystroke to avoid triggering transitions while the user is
+ * still typing.
+ *
+ * @param defaultValue - The initial search query prepopulated in the input.
+ * @param onSearch - Callback invoked with the trimmed query string when search fires.
+ * @param disabled - When `true`, the submit button is disabled (e.g. during a pending transition).
+ * @param className - Additional class names for the wrapper element.
+ * @param i18n - The locale dictionary for translated aria labels.
+ * @returns The search input + button element.
+ */
 export const SearchBar = ({ defaultValue, onSearch, disabled, className, i18n, ...props }: SearchBarProps) => {
     const { t } = getTranslations('common', i18n);
     const [value, setValue] = useState<string>(defaultValue ?? '');
@@ -76,6 +89,7 @@ export const SearchBar = ({ defaultValue, onSearch, disabled, className, i18n, .
     );
 };
 
+/** Props for the `SearchContent` client component. */
 export type SearchContentProps = {
     locale: Locale;
     i18n: LocaleDictionary;
@@ -85,6 +99,21 @@ export type SearchContentProps = {
     productFilters?: ProductFilters;
     totalCount?: number;
 };
+/**
+ * Client component that composes the search page: a `SearchBar`, optional
+ * filter controls, a result count label, and the product card list. Drives
+ * URL replacement via a `useTransition` so the list updates without a full
+ * navigation, showing skeleton cards while the transition is pending.
+ *
+ * @param i18n - The locale dictionary for translated UI copy.
+ * @param locale - The active locale forwarded to the `SearchBar`.
+ * @param showFilters - Whether to render the `Filters` component above the results.
+ * @param productCards - Pre-rendered product card nodes from the server.
+ * @param skeletonCards - Placeholder card nodes shown during pending transitions.
+ * @param productFilters - Shopify product filter facets to expose in the UI.
+ * @param totalCount - Total matching product count for the result count label.
+ * @returns The search page content element.
+ */
 export default function SearchContent({
     i18n,
     locale,

--- a/apps/storefront/src/app/[domain]/[locale]/static-params.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/static-params.ts
@@ -8,6 +8,15 @@ import type { LayoutParams } from './layout';
 
 export type StaticParam = Awaited<LayoutParams>;
 
+/**
+ * Generates the top-level `[domain]/[locale]` path segments for all shops at
+ * build time. Demo shops are skipped; failures per-shop are swallowed and
+ * logged so one bad tenant doesn't abort the entire build. Returns a sentinel
+ * entry when no valid shops are found so Cache Components has at least one
+ * path to render.
+ *
+ * @returns An array of `{ domain, locale }` params for each live shop.
+ */
 export async function generateStaticParams(): Promise<StaticParam[]> {
     try {
         const shops = await Shop.findAll();

--- a/apps/storefront/src/auth/auth.config.ts
+++ b/apps/storefront/src/auth/auth.config.ts
@@ -5,6 +5,15 @@ import ShopifyProvider from '@/auth/shopify-provider';
 
 const IS_PROD = process.env.NODE_ENV === 'production';
 
+/**
+ * Builds the NextAuth configuration for a given shop and Shopify OAuth
+ * credentials, scoping session cookies to the shop's apex domain in
+ * production.
+ *
+ * @param shop - The tenant shop record used for domain scoping.
+ * @param shopifyAuth - The Shopify Customer Accounts API credentials.
+ * @returns A NextAuth-compatible config object.
+ */
 const config = ({
     shop,
     shopifyAuth,

--- a/apps/storefront/src/auth/auth.ts
+++ b/apps/storefront/src/auth/auth.ts
@@ -7,6 +7,16 @@ import NextAuth from 'next-auth';
 
 import getAuthConfig from './auth.config';
 
+/**
+ * Instantiates the NextAuth handler for a given shop by wiring up the shop's
+ * Shopify Customer Accounts API credentials. Throws early if the shop is not
+ * on the Shopify provider or if customer auth is not configured.
+ *
+ * @param shop - The tenant shop record.
+ * @returns The NextAuth handler bound to the shop's credentials.
+ * @throws {UnknownCommerceProviderError} When the shop's commerce provider is not Shopify.
+ * @throws {InvalidShopifyCustomerAccountsApiConfiguration} When the shop has no customer auth config.
+ */
 export function getAuth(shop: OnlineShop) {
     if (shop.commerceProvider.type !== 'shopify') {
         throw new UnknownCommerceProviderError();
@@ -34,6 +44,8 @@ export function getAuth(shop: OnlineShop) {
  *
  * @param shop - The shop to get the auth session for.
  * @returns The auth session.
+ * @throws {UnknownCommerceProviderError} When the shop's commerce provider is not Shopify.
+ * @throws {InvalidShopifyCustomerAccountsApiConfiguration} When the shop has no customer auth config.
  */
 export async function getAuthSession(shop: OnlineShop) {
     return getAuth(shop).auth();

--- a/apps/storefront/src/auth/shopify-provider.ts
+++ b/apps/storefront/src/auth/shopify-provider.ts
@@ -14,6 +14,12 @@ const GET_CUSTOMER_FOR_SESSION = /* GraphQL */ `
 `;
 
 type UntypedValue = unknown;
+
+/**
+ * OIDC ID-token claims returned by the Shopify Customer Accounts API after a
+ * successful OAuth authorization. Extended with an index signature to satisfy
+ * Auth.js's `Profile` constraint.
+ */
 export interface ShopifyProfile extends Record<string, UntypedValue> {
     iss: string;
     sub: string;
@@ -28,6 +34,10 @@ export interface ShopifyProfile extends Record<string, UntypedValue> {
     email_verified: boolean;
 }
 
+/**
+ * Shopify-specific fields required to bootstrap the Customer Accounts OIDC
+ * provider; extends or overrides the standard `OIDCConfig` shape.
+ */
 export interface ShopifyOwnConfig {
     shopId: string;
     clientId: string;
@@ -39,10 +49,19 @@ export interface ShopifyOwnConfig {
     nextAuthCallbackUrl?: string;
 }
 
+/**
+ * Fully resolved Shopify OIDC provider configuration, merging Shopify's own
+ * fields with the standard `OIDCConfig` shape (excluding the fields that
+ * Shopify overrides with its own types).
+ */
 export interface ShopifyConfig<P extends ShopifyProfile>
     extends ShopifyOwnConfig,
         Omit<OIDCConfig<P>, 'clientId' | 'clientSecret' | 'issuer'> {}
 
+/**
+ * Caller-supplied configuration for `ShopifyProvider`. Only Shopify's own
+ * fields are required; all standard OIDC fields are optional overrides.
+ */
 export type ShopifyUserConfig<P extends ShopifyProfile> = ShopifyOwnConfig &
     Partial<Omit<OIDCUserConfig<P>, 'options' | 'type'>>;
 
@@ -69,6 +88,16 @@ export interface ShopifyJWTAuthorizationConformedPayload extends ShopifyJWTAutho
     aud: string;
 }
 
+/**
+ * Builds a fully-configured Auth.js OIDC provider for Shopify's Customer
+ * Accounts API. Handles endpoint construction, JWT conformance (Shopify's
+ * id_token omits `aud` and uses a non-standard `iss`), and customer profile
+ * fetching via the Customer GraphQL API.
+ *
+ * @param options - Shopify OAuth credentials and optional OIDC overrides.
+ * @param shop - The tenant shop record, used to derive the callback URL.
+ * @returns The resolved `ShopifyConfig` ready to be passed to `NextAuth`.
+ */
 function ShopifyProvider<P extends ShopifyProfile = ShopifyProfile>(
     options: ShopifyUserConfig<P>,
     shop: OnlineShop,

--- a/apps/storefront/src/blocks/banner.tsx
+++ b/apps/storefront/src/blocks/banner.tsx
@@ -6,6 +6,14 @@ import type { BlockContext } from './context';
 import { resolveLink } from './resolve-link';
 import type { BannerBlockNode } from './types';
 
+/**
+ * Wraps a URL string in a CSS `url()` value with the inner string
+ * single-quoted and unsafe characters escaped so the value can be safely
+ * embedded in a style attribute without breaking out of the quoted CSS string.
+ *
+ * @param raw - The raw URL to wrap.
+ * @returns A CSS `url('...')` string safe for use in inline styles.
+ */
 const cssUrl = (raw: string): string => {
     // Escape characters that would break out of the quoted CSS string —
     // backslash, single quote, and any line break (CSS strings can't span
@@ -26,6 +34,10 @@ const cssUrl = (raw: string): string => {
  *
  * `alignment` controls horizontal text alignment; mobile is always
  * centered for legibility, alignment kicks in at md+ widths.
+ *
+ * @param block - The CMS banner block node with heading, alignment, and optional CTA/background.
+ * @param context - Render context carrying locale and other block-tree metadata.
+ * @returns The rendered banner section element.
  */
 export const BannerBlock = ({ block, context }: { block: BannerBlockNode; context: BlockContext }): JSX.Element => {
     const bgUrl = typeof block.background === 'string' ? undefined : block.background?.url;
@@ -77,6 +89,9 @@ BannerBlock.displayName = 'Nordcom.Blocks.Banner';
  * editor configured — important for CLS, because a banner above the
  * fold otherwise shifts the entire viewport when the real heading and
  * CTA land.
+ *
+ * @param block - The CMS banner block node; used to mirror the live block's structure for accurate sizing.
+ * @returns The skeleton banner section element.
  */
 const BannerBlockSkeleton = ({ block }: { block: BannerBlockNode }): JSX.Element => {
     const hasCta = Boolean(block.cta);

--- a/apps/storefront/src/blocks/columns.tsx
+++ b/apps/storefront/src/blocks/columns.tsx
@@ -25,12 +25,26 @@ const WIDTH_TO_FRACTION: Record<ColumnsBlockNode['columns'][number]['width'], st
     full: '1fr',
 };
 
+/**
+ * Props for `ColumnsBlock` and `ColumnsBlockSkeleton`. The `Renderer` is
+ * injected rather than imported to keep the block tree acyclic — the
+ * dispatcher (`blocks.tsx`) owns the recursion guard and dispatches back here.
+ */
 export type ColumnsBlockProps = {
     block: ColumnsBlockNode;
     context: BlockContext;
     Renderer: (props: { blocks: BlockNode[]; context: BlockContext }) => ReactNode;
 };
 
+/**
+ * Renders the CMS Columns block, laying out child blocks in a responsive
+ * CSS grid where each column's track size is driven by its `width` enum.
+ *
+ * @param block - The CMS columns block node with column definitions and nested content.
+ * @param context - Render context; depth is incremented before being forwarded to nested blocks.
+ * @param Renderer - Injected block dispatcher used for recursion into nested block arrays.
+ * @returns The rendered columns section element.
+ */
 export const ColumnsBlock = ({ block, context, Renderer }: ColumnsBlockProps) => {
     const nestedContext: BlockContext = { ...context, depth: (context.depth ?? 0) + 1 };
 
@@ -72,6 +86,11 @@ ColumnsBlock.displayName = 'Nordcom.Blocks.Columns';
  *
  * Like the live block, the dispatcher is injected via `Renderer` so the
  * import graph stays acyclic between `columns.tsx` and `blocks.tsx`.
+ *
+ * @param block - The CMS columns block node; used to mirror grid structure and column count.
+ * @param context - Render context; depth is incremented before being forwarded to nested skeleton blocks.
+ * @param Renderer - Injected block dispatcher for recursing into nested skeleton block arrays.
+ * @returns The skeleton columns section element.
  */
 const ColumnsBlockSkeleton = ({ block, context, Renderer }: ColumnsBlockProps) => {
     const nestedContext: BlockContext = { ...context, depth: (context.depth ?? 0) + 1 };

--- a/apps/storefront/src/blocks/media-grid.tsx
+++ b/apps/storefront/src/blocks/media-grid.tsx
@@ -6,21 +6,33 @@ import type { BlockContext } from './context';
 import { type ResolvedLink, resolveLink } from './resolve-link';
 import type { MediaGridBlockNode, MediaItem } from './types';
 
-// Pulls the displayable metadata off a MediaItem. `id` is the Payload media
-// document ID, which we use to derive a stable React `key` (the URL alone
-// can collide when the same asset is referenced twice in one grid; the
-// array index would otherwise reshuffle when the editor reorders items).
+/**
+ * Extracts the displayable metadata from a `MediaItem`. The Payload media
+ * document ID (`id`) is returned so callers can build stable React keys —
+ * using the URL alone collides when the same asset appears twice in a grid.
+ *
+ * @param item - The CMS media item to extract metadata from.
+ * @returns The media document ID, resolved URL, and alt text.
+ */
 const imageMeta = (item: MediaItem): { id?: string; url?: string; alt: string } => {
     if (!item.image) return { id: undefined, url: undefined, alt: '' };
     if (typeof item.image === 'string') return { id: item.image, url: undefined, alt: '' };
     return { id: item.image.id, url: item.image.url, alt: item.image.alt ?? '' };
 };
 
-// Conditional `Link`-or-`div` wrapper. Done as a helper rather than a
-// `WrapperTag = link ? Link : 'div'` union because TypeScript can't narrow
-// the prop union (Link requires `href`; div forbids it) when the component
-// type itself is a union — splitting at the call site is the simplest
-// type-safe shape.
+/**
+ * Wraps media grid children in a `Link` when a resolved link is present,
+ * falling back to a plain `div`. The component-type union approach isn't
+ * used here because TypeScript can't narrow the prop union when the component
+ * type itself is a union — splitting at the call site is the simplest
+ * type-safe shape.
+ *
+ * @param link - The resolved link target, or `null` for an unlinked item.
+ * @param title - Optional title attribute forwarded to the wrapper element.
+ * @param className - Class string applied to the wrapper element.
+ * @param children - The media content to wrap.
+ * @returns A `Link` element when linked, otherwise a `div`.
+ */
 const ItemWrapper = ({
     link,
     title,
@@ -59,6 +71,10 @@ ItemWrapper.displayName = 'Nordcom.Blocks.MediaGrid.Item';
  *
  * Column count is editor-supplied (1–6); we cap the responsive grid at
  * the schema's max, mobile collapses to a single column for legibility.
+ *
+ * @param block - The CMS media-grid block node with items, column count, and item type.
+ * @param context - Render context carrying locale used for link resolution.
+ * @returns The rendered media-grid section, or `null` when the block has no items.
  */
 export const MediaGridBlock = ({
     block,
@@ -168,6 +184,9 @@ MediaGridBlock.displayName = 'Nordcom.Blocks.MediaGrid';
  *
  * Tile aspect ratio mirrors the live block (4:3 for images, square chip
  * for icons) so images popping in don't shift the page.
+ *
+ * @param block - The CMS media-grid block node; used to mirror grid structure and item count.
+ * @returns The skeleton media-grid section, or `null` when the block has no items.
  */
 const MediaGridBlockSkeleton = ({ block }: { block: MediaGridBlockNode }): JSX.Element | null => {
     if (!block.items?.length) return null;

--- a/apps/storefront/src/blocks/resolve-link.ts
+++ b/apps/storefront/src/blocks/resolve-link.ts
@@ -24,6 +24,15 @@ const SAFE_SCHEME = /^(?:https?|mailto|tel):/i;
 // Pre-`kind` data sometimes stored bare paths or hash fragments. Those are
 // fine — only block embedded scripts.
 const SAFE_RELATIVE = /^(?:\/|#|\?)/;
+/**
+ * Returns `true` when `raw` is a URL that the browser can navigate to safely:
+ * an absolute URL with an `http`, `https`, `mailto`, or `tel` scheme, or a
+ * relative path/fragment/query string. Blocks `javascript:`, `data:`, and
+ * any other scheme that could execute code on click.
+ *
+ * @param raw - The raw URL string to validate.
+ * @returns Whether the URL is safe to use as an anchor `href`.
+ */
 const isSafeExternalUrl = (raw: string): boolean => {
     const trimmed = raw.trim();
     if (!trimmed) return false;
@@ -31,8 +40,25 @@ const isSafeExternalUrl = (raw: string): boolean => {
     return SAFE_SCHEME.test(trimmed);
 };
 
+/**
+ * Extracts the `slug` from a Payload relation field that may be a bare ID
+ * string (not populated) or an object, returning `undefined` in both the
+ * string and null/undefined cases.
+ *
+ * @param v - The Payload relation value to extract from.
+ * @returns The slug string, or `undefined` when the relation is not populated.
+ */
 const slugOf = (v: { slug?: string } | string | null | undefined): string | undefined =>
     typeof v === 'string' || !v ? undefined : v.slug;
+
+/**
+ * Extracts the `shopifyHandle` from a Payload relation field that may be a
+ * bare ID string (not populated) or an object, returning `undefined` in both
+ * the string and null/undefined cases.
+ *
+ * @param v - The Payload relation value to extract from.
+ * @returns The Shopify handle string, or `undefined` when the relation is not populated.
+ */
 const handleOf = (v: { shopifyHandle?: string } | string | null | undefined): string | undefined =>
     typeof v === 'string' || !v ? undefined : v.shopifyHandle;
 
@@ -45,6 +71,10 @@ export type ResolvedLink = { href: string; openInNewTab: boolean };
  *
  * Locale is required for internal links because the storefront routes are
  * locale-scoped — `/[locale]/<slug>/` and `/[locale]/products/<handle>/`.
+ *
+ * @param link - The Payload LinkRef to resolve, or `null`/`undefined` for no link.
+ * @param locale - The active locale, used to prefix internal route paths.
+ * @returns The resolved href and `openInNewTab` flag, or `null` when the link is invalid.
  */
 export const resolveLink = (link: LinkRef | null | undefined, { locale }: { locale: Locale }): ResolvedLink | null => {
     if (!link) return null;

--- a/apps/storefront/src/blocks/rich-text-renderer.tsx
+++ b/apps/storefront/src/blocks/rich-text-renderer.tsx
@@ -99,6 +99,15 @@ type LexicalNode =
 
 export type LexicalRoot = { root?: { children?: LexicalNode[] } } | null | undefined;
 
+/**
+ * Converts a Lexical text node to a React node with inline format marks
+ * (bold, italic, underline, strikethrough, code, sub/superscript) applied
+ * inside-out to match Lexical's apply order.
+ *
+ * @param node - The Lexical text node to render.
+ * @param idx - The React list key index within the parent's children array.
+ * @returns A `Fragment` wrapping the text with any format marks applied.
+ */
 const renderText = (node: LexicalTextNode, idx: number): ReactNode => {
     const format = node.format ?? 0;
     let element: ReactNode = node.text;
@@ -115,9 +124,28 @@ const renderText = (node: LexicalTextNode, idx: number): ReactNode => {
     return <Fragment key={idx}>{element}</Fragment>;
 };
 
+/**
+ * Maps a Lexical children array to React nodes by delegating each child to
+ * `renderNode`. Returns an empty array when `children` is absent.
+ *
+ * @param children - The Lexical child nodes to render, or `undefined`.
+ * @param locale - The active locale forwarded to nested link resolution.
+ * @returns An array of React nodes, one per child.
+ */
 const renderChildren = (children: LexicalNode[] | undefined, locale: Locale): ReactNode =>
     (children ?? []).map((child, idx) => renderNode(child, idx, locale));
 
+/**
+ * Dispatches a single Lexical node to its corresponding React element.
+ * Unknown node types fall back to a `Fragment` wrapping their children so
+ * content is never silently dropped when new node types ship ahead of this
+ * renderer.
+ *
+ * @param node - The Lexical node to render.
+ * @param idx - The React list key index within the parent's children array.
+ * @param locale - The active locale used for link href resolution.
+ * @returns The React node for the given Lexical node.
+ */
 const renderNode = (node: LexicalNode, idx: number, locale: Locale): ReactNode => {
     const type = (node as { type?: string }).type;
 
@@ -202,6 +230,10 @@ export type RichTextProps = {
  * Locale-map unwrapping happens upstream in
  * `apps/storefront/src/api/_normalize-payload.ts` — the renderer trusts
  * its input.
+ *
+ * @param data - The Lexical document root to render.
+ * @param locale - The active locale forwarded to link resolution within the document.
+ * @returns The rendered React node tree, or `null` for an empty document.
  */
 export const RichText = ({ data, locale }: RichTextProps): ReactNode => {
     const children = data?.root?.children;
@@ -212,6 +244,9 @@ export const RichText = ({ data, locale }: RichTextProps): ReactNode => {
 /**
  * Quick predicate so block components can skip wrapping empty rich-text
  * regions in containers (e.g. the Banner subheading area).
+ *
+ * @param data - The Lexical document root to check.
+ * @returns `true` when the document has no content or only an empty initial paragraph.
  */
 export const isRichTextEmpty = (data: LexicalRoot): boolean => {
     const children = data?.root?.children;

--- a/apps/storefront/src/blocks/vendors.tsx
+++ b/apps/storefront/src/blocks/vendors.tsx
@@ -11,6 +11,14 @@ import type { VendorsBlockNode } from './types';
 const VENDOR_RAIL_CLASS =
     'overflow-x-shadow -my-2 -ml-2 flex w-screen min-w-screen flex-nowrap gap-2 overflow-x-auto p-2 md:mx-0 md:my-0 md:grid md:w-full md:grid-cols-[repeat(auto-fit,minmax(min(8rem,100%),1fr))] md:overflow-x-hidden md:px-0 md:py-0';
 
+/**
+ * Renders a row of chip-sized skeleton placeholders for the vendor rail,
+ * matching the same horizontal-scroll-on-mobile / auto-fit grid layout used
+ * by the live block to prevent layout shift when content loads.
+ *
+ * @param count - Number of skeleton chips to render; defaults to 8.
+ * @returns The skeleton rail element.
+ */
 const VendorRailSkeleton = ({ count = 8 }: { count?: number }) => (
     <div className={VENDOR_RAIL_CLASS}>
         {Array.from({ length: count }).map((_, idx) => (
@@ -32,6 +40,10 @@ const VendorRailSkeleton = ({ count = 8 }: { count?: number }) => (
  * The inner `Vendors` fetcher is wrapped in `Suspense` so the title +
  * surrounding blocks paint immediately and the vendor pills stream in
  * with the skeleton acting as a placeholder.
+ *
+ * @param block - The CMS vendors block node with optional title and max vendor count.
+ * @param context - Render context carrying shop and locale for the underlying Vendors fetch.
+ * @returns The rendered vendors section element.
  */
 export const VendorsBlock = ({ block, context }: { block: VendorsBlockNode; context: BlockContext }) => {
     return (
@@ -56,6 +68,9 @@ VendorsBlock.displayName = 'Nordcom.Blocks.Vendors';
  * Loading placeholder for the Vendors block. Title slot mirrors the
  * editor-set value; the rail uses the same scroll layout with chip-sized
  * skeletons so the row height is stable when the real data arrives.
+ *
+ * @param block - The CMS vendors block node; used to mirror the title slot and skeleton chip count.
+ * @returns The skeleton vendors section element.
  */
 const VendorsBlockSkeleton = ({ block }: { block: VendorsBlockNode }) => {
     return (

--- a/apps/storefront/src/cart/cart-client-shell.tsx
+++ b/apps/storefront/src/cart/cart-client-shell.tsx
@@ -18,6 +18,11 @@ const PREDICTORS = {
     cart: [quantitySumPredictor(), subtotalPredictor()],
 };
 
+/**
+ * Props for `CartClientShell`. The kernel snapshot and `submitMutation` are
+ * typically passed down from the Server Component that owns cart I/O, keeping
+ * all server-side cart logic outside the client bundle.
+ */
 export interface CartClientShellProps {
     kernelSnapshot: {
         type: string;
@@ -30,6 +35,18 @@ export interface CartClientShellProps {
     children: ReactNode;
 }
 
+/**
+ * Client boundary that mounts the cart provider with optimistic predictors
+ * and the app's auth bridge. All actual cart mutation logic is delegated to
+ * the `submitMutation` Server Action passed from the parent Server Component.
+ *
+ * @param kernelSnapshot - The serialized cart kernel state used to hydrate the provider.
+ * @param submitMutation - The Server Action that processes cart mutation envelopes.
+ * @param initialCart - The initial cart snapshot from the server render, or `null`.
+ * @param shopId - The Shopify shop ID used by the cart provider for API calls.
+ * @param children - The application subtree that can access the cart context.
+ * @returns The rendered `CartProvider` wrapping the children.
+ */
 export function CartClientShell({
     kernelSnapshot,
     submitMutation,

--- a/apps/storefront/src/middleware/admin.ts
+++ b/apps/storefront/src/middleware/admin.ts
@@ -9,6 +9,15 @@ export const ADMIN_HOSTNAME = process.env.ADMIN_DOMAIN ?? 'admin.localhost';
 // path traversal through the trusted-domain redirect.
 const VALID_HOSTNAME = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*$/i;
 
+/**
+ * Handles requests whose first path segment is `admin` by redirecting to the
+ * admin app at `ADMIN_HOSTNAME`. Validates the request hostname against a
+ * strict allowlist regex before redirecting to prevent path-traversal attacks
+ * where a crafted `Host` header could produce a malicious redirect target.
+ *
+ * @param req - The incoming Next.js edge request.
+ * @returns A redirect to the admin app, or a 400 response for an invalid hostname.
+ */
 export const admin = async (req: NextRequest): Promise<NextResponse> => {
     const url = req.nextUrl.clone();
     const hostname = url.hostname;

--- a/apps/storefront/src/middleware/common-validations.ts
+++ b/apps/storefront/src/middleware/common-validations.ts
@@ -2,6 +2,15 @@ import type { NextURL } from 'next/dist/server/web/next-url';
 
 export const DOUBLE_SLASHES = /\/\//g;
 
+/**
+ * Applies a suite of normalizations to a URL string or object: strips
+ * `x-default/` prefixes, collapses double hyphens, deduplicates slashes,
+ * ensures a trailing slash on non-file paths, and normalizes locale casing to
+ * `en-US` form. Accepts a string or URL-like object and returns the same type.
+ *
+ * @param url - The URL string or URL object to normalize.
+ * @returns The same type as the input with all normalizations applied.
+ */
 export const commonValidations = <T extends string | NextURL | URL>(url: T): T => {
     let path: string = '';
     if (typeof url === 'string') {

--- a/apps/storefront/src/middleware/storefront.ts
+++ b/apps/storefront/src/middleware/storefront.ts
@@ -44,6 +44,15 @@ async function resolveDevShopDomain(): Promise<string> {
     return cachedDevShopDomain;
 }
 
+/**
+ * Extracts the effective shop hostname from an incoming request. On dev hosts
+ * (`localhost`, `.test`, etc.) falls back to the dev-shop resolution so
+ * any subdomain form (including `storefront.localhost:1337`) resolves
+ * correctly without requiring a real Shopify shop.
+ *
+ * @param req - The incoming Next.js edge request.
+ * @returns The resolved shop hostname for tenant lookup.
+ */
 async function hostnameFromRequest(req: NextRequest): Promise<string> {
     const host = req.headers.get('x-forwarded-host') || req.headers.get('host') || req.nextUrl.host;
 
@@ -59,6 +68,14 @@ async function hostnameFromRequest(req: NextRequest): Promise<string> {
     return shopFromHost(host);
 }
 
+/**
+ * Resolves the canonical shop domain from a request, verifying it exists in
+ * the MongoDB `shops` collection before returning it.
+ *
+ * @param req - The incoming Next.js edge request.
+ * @returns The verified shop domain string.
+ * @throws {NotFoundError} When no shop with the resolved hostname exists in the database.
+ */
 export const getHostname = async (req: NextRequest): Promise<string> => {
     const hostname = await hostnameFromRequest(req);
     const domain = (await Shop.findByDomain(hostname, { sensitiveData: true })).domain;
@@ -70,6 +87,14 @@ export const getHostname = async (req: NextRequest): Promise<string> => {
     return domain;
 };
 
+/**
+ * Applies a batch of key/value pairs as cookies on an existing response.
+ * Returns the response unchanged when the list is empty.
+ *
+ * @param res - The Next.js response to mutate.
+ * @param cookies - An array of `[key, value]` pairs to set on the response.
+ * @returns The same response with the cookies applied.
+ */
 async function setCookies(res: NextResponse, cookies: string[][] = []): Promise<NextResponse> {
     if (cookies.length <= 0) {
         return res;
@@ -79,6 +104,16 @@ async function setCookies(res: NextResponse, cookies: string[][] = []): Promise<
     return res;
 }
 
+/**
+ * Builds an error-page rewrite response for a commerce error. Rewrites to
+ * the global service domain's status pages so tenants see a branded error
+ * instead of a raw Next.js error overlay. Degrades to a 503 response when
+ * the `SERVICE_DOMAIN` env var is not set.
+ *
+ * @param req - The incoming Next.js edge request, used to derive the shop hostname.
+ * @param error - The commerce error to respond to; `NotFoundError` maps to `/status/unknown-shop/`.
+ * @returns A `NextResponse.rewrite` to the appropriate error page, or a 503 response on misconfiguration.
+ */
 async function handleCommerceError(req: NextRequest, error: Error) {
     const hostname = await hostnameFromRequest(req);
 
@@ -138,6 +173,16 @@ const FILE_TEST = /\.[a-zA-Z]{2,6}$/i;
 const LOCALE_TEST = /\/([a-zA-Z]{2}-[a-zA-Z]{2})/;
 const LOCALE_SLASH_TEST = /\/([a-zA-Z]{2}-[a-zA-Z]{2})\//g;
 
+/**
+ * Tenant-aware storefront middleware. Resolves the request hostname to a
+ * shop, injects the locale into the URL path (reading the `localization`
+ * cookie or the `Accept-Language` header when absent), normalizes URL
+ * casing and trailing slashes, then rewrites the request to the tenanted
+ * App Router path `/[domain]/[locale]/…`.
+ *
+ * @param req - The incoming Next.js edge request.
+ * @returns A redirect, rewrite, or error response depending on tenant and locale resolution.
+ */
 export const storefront = async (req: NextRequest): Promise<NextResponse> => {
     let newUrl = req.nextUrl.clone();
     const cookies: string[][] = [];

--- a/apps/storefront/src/models/VendorModel.ts
+++ b/apps/storefront/src/models/VendorModel.ts
@@ -1,3 +1,7 @@
+/**
+ * Minimal vendor data shape used across storefront product listing and block
+ * components — just the Shopify vendor handle and display title.
+ */
 export interface VendorModel {
     handle: string;
     title: string;

--- a/apps/storefront/src/proxy.ts
+++ b/apps/storefront/src/proxy.ts
@@ -23,12 +23,28 @@ export const config = {
 const VISITOR_COOKIE = 'nordcom-visitor-id';
 const VISITOR_HEADER = 'x-nordcom-visitor-id';
 
+/**
+ * Reads or mints a stable visitor ID for analytics without depending on auth.
+ * If no cookie exists, generates a new UUID and signals that it must be set on
+ * the response.
+ *
+ * @param req - The incoming Next.js edge request.
+ * @returns The visitor ID and whether it already existed in the request cookies.
+ */
 function ensureVisitorId(req: NextRequest): { id: string; existed: boolean } {
     const existing = req.cookies.get(VISITOR_COOKIE)?.value;
     if (existing) return { id: existing, existed: true };
     return { id: randomUUID(), existed: false };
 }
 
+/**
+ * Routes an incoming request to the appropriate sub-middleware based on the
+ * first URL path segment, bypassing tenant resolution for admin and Vercel
+ * well-known paths.
+ *
+ * @param req - The incoming Next.js edge request.
+ * @returns The response produced by the matched sub-middleware.
+ */
 async function dispatch(req: NextRequest): Promise<NextResponse> {
     const url = req.nextUrl.clone();
     const pathname = url.pathname;
@@ -45,6 +61,13 @@ async function dispatch(req: NextRequest): Promise<NextResponse> {
     return storefront(req);
 }
 
+/**
+ * Next.js middleware entry point. Ensures every request carries a stable
+ * visitor ID cookie, then delegates routing to dispatch.
+ *
+ * @param req - The incoming Next.js edge request.
+ * @returns The final response with the visitor cookie set when newly minted.
+ */
 export default async function proxy(req: NextRequest): Promise<NextResponse> {
     const { id: visitorId, existed } = ensureVisitorId(req);
     if (!existed) {


### PR DESCRIPTION
Backfills Tier-2 JSDoc on all in-scope functions and React components in `apps/storefront` that were not handled by the parallel `components`, `utils`, or `api` generators.

**32 files, ~650 lines of JSDoc added across:**
- `src/proxy.ts` — `ensureVisitorId`, `dispatch`, `proxy`
- `src/auth/` — `config`, `getAuth`, `getAuthSession`, `ShopifyProfile`, `ShopifyOwnConfig`, `ShopifyConfig`, `ShopifyUserConfig`, `ShopifyProvider`
- `src/blocks/` — `banner`, `columns`, `media-grid`, `resolve-link`, `rich-text-renderer`, `vendors` (all exported/internal functions and components)
- `src/cart/cart-client-shell.tsx` — `CartClientShellProps`, `CartClientShell`
- `src/middleware/` — `admin`, `commonValidations`, `hostnameFromRequest`, `getHostname`, `setCookies`, `handleCommerceError`, `storefront`
- `src/app/.../static-params.ts` files — 6 `generateStaticParams` exports
- `src/app/.../metadata.ts` — `generateMetadata`
- `src/app/.../cart/` — `CartContent`, `CartSidebar`
- `src/app/.../collections/.../collection-content.tsx` — `CollectionContent`
- `src/app/.../countries/locale-selector.tsx` — `LocaleSelector`
- `src/app/.../products/` — `ProductContent`, `ProductSavings`, `ProductIngredients`, `ProductOriginalName`, `ProductDetails`, `ProductsContent`
- `src/app/.../search/` — `SearchBar`, `SearchContent`, `SearchContentGate`, `SearchContentGateSkeleton`
- `src/app/.../_actions/cart.ts` — all 20 server action exports with mandatory `@throws`
- `src/models/VendorModel.ts` — `VendorModel` interface

All `'use server'` action exports include `@throws`. Typecheck and lint pass cleanly.