### PR TITLE
docs(admin): backfill JSDoc on all functions and components

### DIFF
--- a/apps/admin/src/app/(app)/(auth)/auth/logout/logout-action.tsx
+++ b/apps/admin/src/app/(app)/(auth)/auth/logout/logout-action.tsx
@@ -3,6 +3,9 @@
 import { signOut } from 'next-auth/react';
 import { useEffect } from 'react';
 
+/**
+ * Client component that triggers a NextAuth sign-out on mount and redirects to the app root.
+ */
 export const LogoutAction = ({}) => {
     useEffect(() => {
         signOut({ callbackUrl: '/' });

--- a/apps/admin/src/app/(app)/(dashboard)/[domain]/settings/media/upload/upload-form.tsx
+++ b/apps/admin/src/app/(app)/(dashboard)/[domain]/settings/media/upload/upload-form.tsx
@@ -28,12 +28,16 @@ export type UploadFormProps = {
  * Invokes a server action that authenticates via NextAuth and dispatches into
  * `payload.create` with the file payload. On success it redirects to the new
  * doc's edit page (or back to the grid on failure).
+ *
+ * @param props.domain - The current shop domain used to construct the post-upload redirect URL.
+ * @param props.createAction - Pre-bound server action `(formData: FormData) => Promise<{ id: string }>`.
  */
 export function UploadForm({ domain, createAction }: UploadFormProps) {
     const router = useRouter();
     const [isPending, startTransition] = useTransition();
     const [error, setError] = useState<string | null>(null);
 
+    /** Submits the form via the bound server action and redirects to the new media document on success. @param e - The form submit event. */
     function handleSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
         setError(null);

--- a/apps/admin/src/components/avatar.tsx
+++ b/apps/admin/src/components/avatar.tsx
@@ -4,6 +4,11 @@ import * as AvatarPrimitive from '@radix-ui/react-avatar';
 import * as React from 'react';
 import { cn } from '@/utils/tailwind';
 
+/**
+ * Circular avatar container sized at 36 px (size-9). Wraps Radix's Avatar root.
+ *
+ * @param props.className - Additional class names merged onto the root element.
+ */
 const Avatar = React.forwardRef<
     React.ElementRef<typeof AvatarPrimitive.Root>,
     React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
@@ -16,6 +21,11 @@ const Avatar = React.forwardRef<
 ));
 Avatar.displayName = AvatarPrimitive.Root.displayName;
 
+/**
+ * Renders the avatar image; falls back to AvatarFallback when the image fails to load.
+ *
+ * @param props.className - Additional class names merged onto the image element.
+ */
 const AvatarImage = React.forwardRef<
     React.ElementRef<typeof AvatarPrimitive.Image>,
     React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
@@ -24,6 +34,11 @@ const AvatarImage = React.forwardRef<
 ));
 AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 
+/**
+ * Fallback content displayed when the avatar image is absent or fails to load.
+ *
+ * @param props.className - Additional class names merged onto the fallback element.
+ */
 const AvatarFallback = React.forwardRef<
     React.ElementRef<typeof AvatarPrimitive.Fallback>,
     React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>

--- a/apps/admin/src/components/cms/bulk-actions.tsx
+++ b/apps/admin/src/components/cms/bulk-actions.tsx
@@ -10,6 +10,12 @@ export type BulkActionsProps = {
     publishAction?: (ids: string[]) => Promise<void>;
 };
 
+/**
+ * Toolbar that surfaces bulk delete and publish buttons bound to the current BulkSelectionContext.
+ *
+ * @param props.deleteAction - Optional server action invoked with the array of selected ids.
+ * @param props.publishAction - Optional server action invoked with the array of selected ids.
+ */
 export function BulkActions({ deleteAction, publishAction }: BulkActionsProps) {
     const { selectedIds, clearAll } = useBulkSelection();
     const [isPending, startTransition] = useTransition();

--- a/apps/admin/src/components/cms/bulk-selection-provider.tsx
+++ b/apps/admin/src/components/cms/bulk-selection-provider.tsx
@@ -12,6 +12,12 @@ type BulkSelectionContextValue = {
 
 const BulkSelectionContext = createContext<BulkSelectionContextValue | null>(null);
 
+/**
+ * Returns the nearest BulkSelectionContext; throws when no provider is in the tree.
+ *
+ * @returns The context value containing selectedIds, toggle, and clearAll.
+ * @throws {MissingContextProviderError} When called outside a BulkSelectionProvider.
+ */
 export function useBulkSelection(): BulkSelectionContextValue {
     const ctx = useContext(BulkSelectionContext);
     if (!ctx) {
@@ -24,6 +30,11 @@ export type BulkSelectionProviderProps = {
     children: ReactNode;
 };
 
+/**
+ * Provides row-checkbox selection state to all descendant BulkActions and RowCheckbox components.
+ *
+ * @param props.children - Content tree that needs access to the selection context.
+ */
 export function BulkSelectionProvider({ children }: BulkSelectionProviderProps) {
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 

--- a/apps/admin/src/components/cms/collection-table.tsx
+++ b/apps/admin/src/components/cms/collection-table.tsx
@@ -55,10 +55,32 @@ function columnKey<TRow>(col: Column<TRow>, index: number): string {
     return typeof col.accessor === 'function' ? `fn:${index}` : col.accessor;
 }
 
+/**
+ * Resolves a column's cell value for the given row using either the string accessor or the function accessor.
+ *
+ * @param col - Column definition whose accessor drives the lookup.
+ * @param row - The row being rendered.
+ * @returns The resolved cell value (may be null for function-form accessors).
+ */
 function resolveCellValue<TRow>(col: Column<TRow>, row: TRow): unknown {
     return typeof col.accessor === 'function' ? col.accessor(row) : row[col.accessor];
 }
 
+/**
+ * Data table for CMS collection list pages with optional row checkboxes for bulk operations.
+ *
+ * Renders columns, a trailing "Edit" link per row, and wraps the tree in BulkSelectionProvider
+ * automatically when selectable is true.
+ *
+ * @param props.rows - Array of data objects to display; each must have an id field.
+ * @param props.columns - Column definitions controlling header labels and cell rendering.
+ * @param props.getRowHref - Returns the edit route for a given row.
+ * @param props.getRowLabel - Human-readable label per row for screen readers.
+ * @param props.bulkActions - BulkActions slot; rendered only when selectable is true and rows exist.
+ * @param props.selectable - When true, renders row checkboxes and wraps in BulkSelectionProvider.
+ * @param props.emptyMessage - Message displayed when the rows array is empty.
+ * @param props.ariaLabel - aria-label on the underlying table element.
+ */
 export function CollectionTable<TRow extends { id: string | number }>({
     rows,
     columns,

--- a/apps/admin/src/components/cms/create-metadata-for-handle-form.tsx
+++ b/apps/admin/src/components/cms/create-metadata-for-handle-form.tsx
@@ -32,6 +32,10 @@ export type CreateMetadataForHandleFormProps = {
  *
  * Shared between the product-metadata and collection-metadata list pages so
  * both display a consistent "open by handle" affordance.
+ *
+ * @param props.domain - Tenant domain used to build the navigation URL.
+ * @param props.basePath - Content sub-path for the metadata collection, e.g. 'product-metadata'.
+ * @param props.placeholder - Placeholder text for the handle input; defaults to 'Shopify handle…'.
  */
 export function CreateMetadataForHandleForm({ domain, basePath, placeholder }: CreateMetadataForHandleFormProps) {
     const router = useRouter();

--- a/apps/admin/src/components/cms/document-form-body.tsx
+++ b/apps/admin/src/components/cms/document-form-body.tsx
@@ -26,6 +26,10 @@ export type DocumentFormBodyProps = {
  * `<InitialStateGate>` (below) sees a fresh prop AND `useFormModified()` is
  * false — so dirty edits survive every server-side refresh until the user
  * either explicitly saves or steps away long enough for `modified` to clear.
+ *
+ * @param props.action - Server action invoked on explicit form submit.
+ * @param props.initialState - Latest FormState from the server; committed only when the form is clean.
+ * @param props.children - Field components rendered inside the Payload Form context.
  */
 export function DocumentFormBody({ action, initialState, children }: DocumentFormBodyProps) {
     const [committedInitialState, setCommittedInitialState] = useState(initialState);
@@ -51,6 +55,10 @@ type InitialStateGateProps = {
  * Renders nothing; subscribes to `useFormModified()` and commits the parent's
  * latest `initialState` only when the form is clean. Lives inside `<Form>` so
  * the hook can read the form context.
+ *
+ * @param props.latest - Latest initialState prop from the parent.
+ * @param props.committed - Currently committed state held in the parent's useState slot.
+ * @param props.onCommit - Callback that advances the committed slot to the latest value.
  */
 function InitialStateGate({ latest, committed, onCommit }: InitialStateGateProps) {
     const modified = useFormModified();

--- a/apps/admin/src/components/cms/document-form.tsx
+++ b/apps/admin/src/components/cms/document-form.tsx
@@ -20,6 +20,18 @@ export type DocumentFormProps = {
     livePreview?: ReactNode;
 };
 
+/**
+ * Full-page document editor layout combining a PageHeader, Payload field shell, and optional live-preview pane.
+ *
+ * @param props.title - Page heading displayed in PageHeader.
+ * @param props.breadcrumbs - Optional breadcrumb trail rendered above the title.
+ * @param props.shellProps - Props forwarded to PayloadFieldShell (Payload context providers).
+ * @param props.children - Field components rendered inside the form body.
+ * @param props.onSubmit - Server action called on explicit form submit.
+ * @param props.initialState - Payload FormState used to seed the form.
+ * @param props.toolbar - Optional toolbar slot rendered in the sticky PageFooter.
+ * @param props.livePreview - When provided the form body switches to a two-column grid layout.
+ */
 export function DocumentForm({
     title,
     breadcrumbs,

--- a/apps/admin/src/components/cms/draft-publish-toolbar.tsx
+++ b/apps/admin/src/components/cms/draft-publish-toolbar.tsx
@@ -6,7 +6,12 @@ import { useEffect, useState, useTransition } from 'react';
 /** How often (ms) to re-render the toolbar so the relative timestamp stays fresh. */
 const RELATIVE_TIME_TICK_MS = 30_000;
 
-/** Returns a human-readable relative-time string such as "2 minutes ago". */
+/**
+ * Converts a date to a human-readable relative-time string such as "2 minutes ago".
+ *
+ * @param date - The reference point; accepts a Date object or an ISO-format string.
+ * @returns A human-readable relative-time string.
+ */
 export function formatRelativeTime(date: Date | string): string {
     const ms = Date.now() - new Date(date).getTime();
     const seconds = Math.round(ms / 1000);
@@ -48,6 +53,11 @@ export type DraftPublishToolbarProps = {
  * Renders two buttons — "Save Draft" and "Publish" — each guarded by its own
  * `useTransition` so they disable independently during their pending state.
  * Mirrors the `runAction` pattern from `<BulkActions>` for error handling.
+ *
+ * @param props.saveDraftAction - Server action that saves the form as a draft.
+ * @param props.publishAction - Server action that publishes the form.
+ * @param props.lastSavedAt - Timestamp of the last save; undefined if never saved.
+ * @param props.isSaving - When true, shows a "Saving…" indicator next to the timestamp.
  */
 export function DraftPublishToolbar({
     saveDraftAction,

--- a/apps/admin/src/components/cms/live-preview-iframe.tsx
+++ b/apps/admin/src/components/cms/live-preview-iframe.tsx
@@ -51,6 +51,10 @@ export type LivePreviewIframeProps = {
  * We use `iframe.src = iframe.src` instead, which forces a reload without
  * crossing the same-origin policy. This is a well-known workaround documented
  * in MDN's cross-origin iframe section.
+ *
+ * @param props.previewUrl - Fully-assembled preview URL, built server-side to keep the secret out of the RSC boundary.
+ * @param props.domain - Tenant domain used to scope the localStorage open/closed key per shop.
+ * @param props.defaultOpen - When true the panel is initially open; defaults to false.
  */
 export function LivePreviewIframe({ previewUrl, domain, defaultOpen = false }: LivePreviewIframeProps) {
     const storageKey = domain ? `${STORAGE_KEY_PREFIX}.${domain}.open` : `${STORAGE_KEY_PREFIX}.open`;

--- a/apps/admin/src/components/cms/row-checkbox.tsx
+++ b/apps/admin/src/components/cms/row-checkbox.tsx
@@ -11,6 +11,12 @@ export type RowCheckboxProps = {
     rowLabel?: string;
 };
 
+/**
+ * Checkbox cell for bulk-selection tables; reads and writes to the nearest BulkSelectionContext.
+ *
+ * @param props.rowId - Unique string identifier of the row, used as the selection key.
+ * @param props.rowLabel - Human-readable label for the checkbox aria-label.
+ */
 export function RowCheckbox({ rowId, rowLabel }: RowCheckboxProps) {
     const { selectedIds, toggle } = useBulkSelection();
 

--- a/apps/admin/src/components/login-button.tsx
+++ b/apps/admin/src/components/login-button.tsx
@@ -17,6 +17,16 @@ import { cn } from '@/utils/tailwind';
 export type LoginButtonProps = {
     provider?: AuthProvider['name'];
 } & Omit<HTMLProps<HTMLButtonElement>, 'type' | 'onClick'>;
+/**
+ * Login button that initiates a NextAuth sign-in flow for the given provider.
+ *
+ * Reads the `error` search param set by NextAuth on redirect and surfaces it as a toast,
+ * then removes the param from the URL so it doesn't persist on re-render.
+ *
+ * @param props.provider - Auth provider to sign in with; currently only 'github' is supported.
+ * @param props.className - Additional class names merged onto the button.
+ * @throws {TodoError} For any provider not yet implemented.
+ */
 export default function LoginButton({ provider = 'github', className, ...props }: LoginButtonProps) {
     const [loading, setLoading] = useState<boolean>(false);
 

--- a/apps/admin/src/components/modal.tsx
+++ b/apps/admin/src/components/modal.tsx
@@ -7,6 +7,12 @@ import { useRouter } from 'next/router';
 
 import type { ReactNode } from 'react';
 
+/**
+ * Generic modal card with a close button that navigates back in the router history.
+ *
+ * @param props.title - Content rendered in the card header alongside the close button.
+ * @param props.children - Body content rendered inside the card.
+ */
 export function Modal({ title, children }: { title: ReactNode; children: ReactNode }) {
     const router = useRouter();
 

--- a/apps/admin/src/components/providers.tsx
+++ b/apps/admin/src/components/providers.tsx
@@ -13,6 +13,14 @@ import { Toaster } from 'sonner';
 export type ProvidersProps = {
     children: ReactNode;
 };
+/**
+ * Root client provider tree for the admin shell.
+ *
+ * Mounts NordstarProvider, NextTopLoader, Toaster, the global faceless-ui ModalProvider
+ * (required for Payload document drawers to find a ModalContext), and Google Tag Manager.
+ *
+ * @param props.children - Application tree wrapped by all providers.
+ */
 export function Providers({ children }: ProvidersProps) {
     // https://github.com/TheSGJ/nextjs-toploader/issues/56#issuecomment-1820484781
     // this should also trigger on searchParams changes but listening to it would cause

--- a/apps/admin/src/components/shell/account-menu.tsx
+++ b/apps/admin/src/components/shell/account-menu.tsx
@@ -18,6 +18,12 @@ export type AccountMenuUser = { name?: string; email?: string; image?: string; r
 
 export type AccountMenuProps = { user: AccountMenuUser };
 
+/**
+ * Derives two-letter initials from a user's name or email for the avatar fallback.
+ *
+ * @param user - The account user; name is preferred over email, falls back to '?'.
+ * @returns Up to two uppercase initials joined as a string.
+ */
 function initialsOf(user: AccountMenuUser): string {
     const source = user.name ?? user.email ?? '?';
     return source
@@ -27,6 +33,11 @@ function initialsOf(user: AccountMenuUser): string {
         .join('');
 }
 
+/**
+ * Dropdown account menu in the shell header; shows the user's avatar and a sign-out link.
+ *
+ * @param props.user - Authenticated user whose name, email, and image are displayed.
+ */
 export function AccountMenu({ user }: AccountMenuProps) {
     return (
         <DropdownMenu>

--- a/apps/admin/src/components/shell/command-palette-trigger.tsx
+++ b/apps/admin/src/components/shell/command-palette-trigger.tsx
@@ -4,6 +4,9 @@ import { Search } from 'lucide-react';
 
 import { Kbd } from '@/components/ui/kbd';
 
+/**
+ * Search button in the shell header that opens the CommandPalette by dispatching a synthetic ⌘K keyboard event.
+ */
 export function CommandPaletteTrigger() {
     return (
         <button

--- a/apps/admin/src/components/shell/command-palette.tsx
+++ b/apps/admin/src/components/shell/command-palette.tsx
@@ -20,6 +20,11 @@ export type CommandPaletteProps = {
     items: CommandPaletteItem[];
 };
 
+/**
+ * Radix Dialog-based command palette that opens on ⌘K / Ctrl+K and supports grouped navigation items.
+ *
+ * @param props.items - Flat list of navigable items; grouped by the item's group field in the rendered list.
+ */
 export function CommandPalette({ items }: CommandPaletteProps) {
     const router = useRouter();
     const [open, setOpen] = useState(false);

--- a/apps/admin/src/components/shell/content-scroll-region.tsx
+++ b/apps/admin/src/components/shell/content-scroll-region.tsx
@@ -12,6 +12,9 @@ export type ContentScrollRegionProps = {
  * sticky-top / sticky-bottom CSS for any <PageHeader data-page-header /> or
  * <PageFooter data-page-footer /> rendered as a direct child. Pages render
  * their headers/footers inline; this wrapper makes them stick.
+ *
+ * @param props.children - Page content rendered inside the scroll container.
+ * @param props.className - Additional class names merged onto the scroll root.
  */
 export function ContentScrollRegion({ children, className }: ContentScrollRegionProps) {
     return (

--- a/apps/admin/src/components/shell/editor-skeleton.tsx
+++ b/apps/admin/src/components/shell/editor-skeleton.tsx
@@ -1,6 +1,9 @@
 import { PageHeader } from '@/components/shell/page-header';
 import { Skeleton } from '@/components/shell/skeleton';
 
+/**
+ * Full-page loading skeleton for document editor routes while the real content is streaming.
+ */
 export function EditorSkeleton() {
     return (
         <div className="flex h-full min-w-0 flex-col">

--- a/apps/admin/src/components/shell/empty-state.tsx
+++ b/apps/admin/src/components/shell/empty-state.tsx
@@ -12,6 +12,15 @@ export type EmptyStateProps = {
     className?: string;
 };
 
+/**
+ * Centered empty state with an optional description and action link, used on collection list pages with no rows.
+ *
+ * @param props.label - Primary heading text displayed in the empty state.
+ * @param props.description - Secondary explanation shown below the label.
+ * @param props.actionLabel - Button label for the call-to-action link.
+ * @param props.actionHref - Route for the call-to-action; rendered only when both label and href are present.
+ * @param props.className - Additional class names merged onto the container.
+ */
 export function EmptyState({ label, description, actionLabel, actionHref, className }: EmptyStateProps) {
     return (
         <div

--- a/apps/admin/src/components/shell/icon-rail.tsx
+++ b/apps/admin/src/components/shell/icon-rail.tsx
@@ -20,6 +20,12 @@ export type IconRailProps = {
     expanded: boolean;
 };
 
+/**
+ * Vertical navigation rail that renders labeled nav items or icon-only items with tooltips.
+ *
+ * @param props.items - Navigation entries; each has an href, label, icon, and optional disabled state.
+ * @param props.expanded - When true, labels are rendered alongside icons; when false, only icons with hover tooltips.
+ */
 export function IconRail({ items, expanded }: IconRailProps) {
     return (
         <TooltipProvider delayDuration={200}>

--- a/apps/admin/src/components/shell/inspector-slot.tsx
+++ b/apps/admin/src/components/shell/inspector-slot.tsx
@@ -4,6 +4,11 @@ import type { ReactNode } from 'react';
 
 import { ScrollArea } from '@/components/ui/scroll-area';
 
+/**
+ * Scrollable aside panel for the inspector parallel-route slot in the admin shell.
+ *
+ * @param props.children - Inspector content rendered inside the scrollable region.
+ */
 export function InspectorSlot({ children }: { children: ReactNode }) {
     return (
         <aside className="flex h-full min-w-0 flex-col border-0 border-border border-l-2 bg-background">

--- a/apps/admin/src/components/shell/list-skeleton.tsx
+++ b/apps/admin/src/components/shell/list-skeleton.tsx
@@ -1,6 +1,11 @@
 import { PageHeader } from '@/components/shell/page-header';
 import { Skeleton } from '@/components/shell/skeleton';
 
+/**
+ * Full-page loading skeleton for collection list routes while rows are streaming.
+ *
+ * @param props.title - Page title passed to PageHeader; defaults to 'Loading…'.
+ */
 export function ListSkeleton({ title = 'Loading…' }: { title?: string }) {
     return (
         <div className="flex h-full min-w-0 flex-col">

--- a/apps/admin/src/components/shell/mobile-drawer.tsx
+++ b/apps/admin/src/components/shell/mobile-drawer.tsx
@@ -14,6 +14,15 @@ export type MobileDrawerProps = {
     children: ReactNode;
 };
 
+/**
+ * Full-height slide-in drawer for mobile breakpoints, implemented with Radix Dialog.
+ * Closes automatically on route change.
+ *
+ * @param props.side - Which edge the drawer slides in from ('left' or 'right').
+ * @param props.trigger - Element rendered as the Dialog trigger (e.g. a hamburger button).
+ * @param props.title - Accessible title for the dialog; rendered visually-hidden. Defaults to 'Menu'.
+ * @param props.children - Drawer body content.
+ */
 export function MobileDrawer({ side, trigger, title = 'Menu', children }: MobileDrawerProps) {
     const pathname = usePathname();
     const [open, setOpen] = useState(false);

--- a/apps/admin/src/components/shell/mobile-nav.tsx
+++ b/apps/admin/src/components/shell/mobile-nav.tsx
@@ -8,6 +8,12 @@ export type MobileNavProps = {
     subnav: ReactNode;
 };
 
+/**
+ * Stacked navigation list for the mobile drawer; renders icon rail items as text links with an optional subnav section.
+ *
+ * @param props.items - Navigation entries mirroring the desktop icon rail.
+ * @param props.subnav - Optional secondary navigation rendered below a divider.
+ */
 export function MobileNav({ items, subnav }: MobileNavProps) {
     return (
         <nav className="flex flex-col gap-1">

--- a/apps/admin/src/components/shell/page-footer.tsx
+++ b/apps/admin/src/components/shell/page-footer.tsx
@@ -9,6 +9,13 @@ export type PageFooterProps = {
     className?: string;
 };
 
+/**
+ * Page-level footer bar, optionally sticky at the bottom of the ContentScrollRegion.
+ *
+ * @param props.children - Footer content, typically save/publish action buttons.
+ * @param props.sticky - When true (default) the footer sticks to the bottom of the scroll container.
+ * @param props.className - Additional class names merged onto the footer element.
+ */
 export function PageFooter({ children, sticky = true, className }: PageFooterProps) {
     return (
         <div

--- a/apps/admin/src/components/shell/page-header.tsx
+++ b/apps/admin/src/components/shell/page-header.tsx
@@ -14,6 +14,15 @@ export type PageHeaderProps = {
     className?: string;
 };
 
+/**
+ * Page-level header with an h1 title, optional breadcrumb trail, action slot, and metadata slot.
+ *
+ * @param props.title - The h1 heading text.
+ * @param props.breadcrumbs - Optional breadcrumb array; each entry may include an href for navigation.
+ * @param props.actions - Optional slot for page-level action buttons aligned to the right.
+ * @param props.meta - Optional slot for metadata badges or labels rendered below the title row.
+ * @param props.className - Additional class names merged onto the header element.
+ */
 export function PageHeader({ title, breadcrumbs, actions, meta, className }: PageHeaderProps) {
     return (
         <header data-page-header className={cn('flex flex-col gap-2 border-none bg-background p-3', className)}>

--- a/apps/admin/src/components/shell/shell-header.tsx
+++ b/apps/admin/src/components/shell/shell-header.tsx
@@ -23,6 +23,18 @@ export type ShellHeaderProps = {
     mobileNavContent: ReactNode;
 };
 
+/**
+ * Top application bar for the admin shell containing the logo, shop switcher, search trigger, and account menu.
+ *
+ * On compact breakpoints the desktop sidebar is replaced by a MobileDrawer triggered from this header.
+ * The breakpoint gate is client-side to avoid a Radix useId hydration mismatch on the trigger button.
+ *
+ * @param props.shop - The currently active shop for the shop switcher.
+ * @param props.user - Authenticated user for the account menu.
+ * @param props.shopsForSwitcher - All shops available for switching.
+ * @param props.commandPaletteItems - Items rendered in the CommandPalette opened by the search trigger.
+ * @param props.mobileNavContent - Pre-rendered server component tree rendered inside the MobileDrawer.
+ */
 export function ShellHeader({ shop, user, shopsForSwitcher, commandPaletteItems, mobileNavContent }: ShellHeaderProps) {
     // Gate the mobile drawer on the real breakpoint instead of `md:hidden`.
     // SSR + first-client-render both see the default 'comfortable' breakpoint,

--- a/apps/admin/src/components/shell/shell-root.tsx
+++ b/apps/admin/src/components/shell/shell-root.tsx
@@ -35,6 +35,18 @@ const SEPARATOR_CLASSNAME =
 
 export const SHELL_ROOT_ID = 'shell-root';
 
+/**
+ * Resizable panel layout for the admin shell, adapting between mobile (single-column) and desktop (multi-panel) views.
+ *
+ * Manages panel widths via react-resizable-panels, detects parallel-route slot activity to show/hide
+ * the subnav and inspector panels, and observes the rail width to toggle icon-only vs labeled mode.
+ *
+ * @param props.children - Main page content rendered in the center panel.
+ * @param props.subnav - Server-resolved @subnav parallel-route slot.
+ * @param props.inspector - Server-resolved @inspector parallel-route slot.
+ * @param props.header - Pre-rendered header server component.
+ * @param props.iconRailItems - Navigation items passed through to the IconRail.
+ */
 export function ShellRoot({ children, subnav, inspector, header, iconRailItems }: ShellRootProps) {
     const breakpoint = useBreakpoint();
 

--- a/apps/admin/src/components/shell/shop-switcher.tsx
+++ b/apps/admin/src/components/shell/shop-switcher.tsx
@@ -21,6 +21,12 @@ export type ShopSwitcherProps = {
     shops: ShopSwitcherShop[];
 };
 
+/**
+ * Dropdown that lets operators switch between their accessible shops, navigating to the shop's root route on select.
+ *
+ * @param props.current - The currently active shop.
+ * @param props.shops - All shops available in the switcher.
+ */
 export function ShopSwitcher({ current, shops }: ShopSwitcherProps) {
     return (
         <DropdownMenu>

--- a/apps/admin/src/components/shell/skeleton.tsx
+++ b/apps/admin/src/components/shell/skeleton.tsx
@@ -4,6 +4,11 @@ export type SkeletonProps = {
     className?: string;
 };
 
+/**
+ * Animated placeholder block for content that is loading.
+ *
+ * @param props.className - Additional class names merged onto the pulse element; use these to set size.
+ */
 export function Skeleton({ className }: SkeletonProps) {
     return <div className={cn('animate-pulse rounded-md bg-muted', className)} aria-hidden />;
 }

--- a/apps/admin/src/components/shell/sub-nav-slot.tsx
+++ b/apps/admin/src/components/shell/sub-nav-slot.tsx
@@ -2,6 +2,12 @@ import type { ReactNode } from 'react';
 
 import { ScrollArea } from '@/components/ui/scroll-area';
 
+/**
+ * Scrollable aside container for the subnav parallel-route slot in the admin shell.
+ * Renders nothing when children is falsy.
+ *
+ * @param props.children - Subnav content rendered inside the scrollable region.
+ */
 export function SubNavSlot({ children }: { children: ReactNode }) {
     if (!children) return null;
 

--- a/apps/admin/src/components/shell/use-breakpoint.ts
+++ b/apps/admin/src/components/shell/use-breakpoint.ts
@@ -4,6 +4,12 @@ import { useEffect, useState } from 'react';
 
 export type Breakpoint = 'mobile' | 'tablet' | 'compact' | 'comfortable' | 'wide';
 
+/**
+ * Maps a viewport pixel width to the closest named breakpoint.
+ *
+ * @param width - Viewport width in pixels (typically window.innerWidth).
+ * @returns The corresponding Breakpoint name.
+ */
 export function resolveBreakpoint(width: number): Breakpoint {
     if (width >= 1536) return 'wide';
     if (width >= 1280) return 'comfortable';
@@ -12,7 +18,11 @@ export function resolveBreakpoint(width: number): Breakpoint {
     return 'mobile';
 }
 
-/** Returns the current breakpoint; SSR-safe default is 'comfortable'. */
+/**
+ * Returns the current viewport breakpoint; SSR-safe default is 'comfortable'.
+ *
+ * @returns The current breakpoint, updated reactively on window resize.
+ */
 export function useBreakpoint(): Breakpoint {
     const [bp, setBp] = useState<Breakpoint>('comfortable');
     useEffect(() => {

--- a/apps/admin/src/components/ui/button.tsx
+++ b/apps/admin/src/components/ui/button.tsx
@@ -36,6 +36,11 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
  * child (e.g. an `<a>`) and the forwarded ref points to that element rather
  * than an HTMLButtonElement. The `ref as never` cast intentionally widens the
  * ref to permit this — callers using `asChild` must type their own ref.
+ *
+ * @param props.className - Additional class names applied to the button or Slot element.
+ * @param props.variant - Visual variant; defaults to 'primary'.
+ * @param props.size - Size variant; defaults to 'md'.
+ * @param props.asChild - When true the child element acts as the button (Radix Slot pattern).
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ({ className, variant, size, asChild, ...props }, ref) => {

--- a/apps/admin/src/components/ui/command.tsx
+++ b/apps/admin/src/components/ui/command.tsx
@@ -6,6 +6,11 @@ import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from 're
 
 import { cn } from '@/utils/tailwind';
 
+/**
+ * cmdk command menu root container; wraps CommandPrimitive with themed styles.
+ *
+ * @param props.className - Additional class names merged onto the primitive root.
+ */
 export const Command = forwardRef<
     ComponentRef<typeof CommandPrimitive>,
     ComponentPropsWithoutRef<typeof CommandPrimitive>
@@ -22,6 +27,11 @@ export const Command = forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
+/**
+ * Search input bar with a leading magnifier icon, rendered at the top of the Command menu.
+ *
+ * @param props.className - Additional class names merged onto the input element.
+ */
 export const CommandInput = forwardRef<
     ComponentRef<typeof CommandPrimitive.Input>,
     ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
@@ -41,6 +51,11 @@ export const CommandInput = forwardRef<
 ));
 CommandInput.displayName = CommandPrimitive.Input.displayName;
 
+/**
+ * Scrollable viewport for CommandGroup and CommandEmpty items within a Command menu.
+ *
+ * @param props.className - Additional class names merged onto the list element.
+ */
 export const CommandList = forwardRef<
     ComponentRef<typeof CommandPrimitive.List>,
     ComponentPropsWithoutRef<typeof CommandPrimitive.List>
@@ -54,6 +69,11 @@ export const CommandList = forwardRef<
 ));
 CommandList.displayName = CommandPrimitive.List.displayName;
 
+/**
+ * Fallback rendered inside CommandList when no items match the current search query.
+ *
+ * @param props.className - Additional class names merged onto the empty state element.
+ */
 export const CommandEmpty = forwardRef<
     ComponentRef<typeof CommandPrimitive.Empty>,
     ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
@@ -67,6 +87,11 @@ export const CommandEmpty = forwardRef<
 ));
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
+/**
+ * Labeled group of CommandItem entries within a CommandList.
+ *
+ * @param props.className - Additional class names merged onto the group element.
+ */
 export const CommandGroup = forwardRef<
     ComponentRef<typeof CommandPrimitive.Group>,
     ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
@@ -83,6 +108,11 @@ export const CommandGroup = forwardRef<
 ));
 CommandGroup.displayName = CommandPrimitive.Group.displayName;
 
+/**
+ * Selectable command entry that triggers an action on selection via onSelect.
+ *
+ * @param props.className - Additional class names merged onto the item element.
+ */
 export const CommandItem = forwardRef<
     ComponentRef<typeof CommandPrimitive.Item>,
     ComponentPropsWithoutRef<typeof CommandPrimitive.Item>

--- a/apps/admin/src/components/ui/dropdown-menu.tsx
+++ b/apps/admin/src/components/ui/dropdown-menu.tsx
@@ -16,6 +16,12 @@ export function DropdownMenu(props: ComponentProps<typeof Primitive.Root>) {
 export const DropdownMenuTrigger = Primitive.Trigger;
 export const DropdownMenuGroup = Primitive.Group;
 
+/**
+ * Portal-rendered dropdown content panel with animated open/close transitions.
+ *
+ * @param props.className - Additional class names merged onto the content element.
+ * @param props.sideOffset - Pixel gap between the trigger and the content panel; defaults to 4.
+ */
 export const DropdownMenuContent = forwardRef<
     ComponentRef<typeof Primitive.Content>,
     ComponentPropsWithoutRef<typeof Primitive.Content>
@@ -35,6 +41,12 @@ export const DropdownMenuContent = forwardRef<
 ));
 DropdownMenuContent.displayName = Primitive.Content.displayName;
 
+/**
+ * A single actionable row inside a DropdownMenuContent.
+ *
+ * @param props.className - Additional class names merged onto the item element.
+ * @param props.inset - When true adds left padding to align with inset-offset items.
+ */
 export const DropdownMenuItem = forwardRef<
     ComponentRef<typeof Primitive.Item>,
     ComponentPropsWithoutRef<typeof Primitive.Item> & { inset?: boolean }
@@ -51,6 +63,12 @@ export const DropdownMenuItem = forwardRef<
 ));
 DropdownMenuItem.displayName = Primitive.Item.displayName;
 
+/**
+ * Non-interactive label row used as a section heading inside a DropdownMenuContent.
+ *
+ * @param props.className - Additional class names merged onto the label element.
+ * @param props.inset - When true adds left padding to align with inset-offset items.
+ */
 export const DropdownMenuLabel = forwardRef<
     ComponentRef<typeof Primitive.Label>,
     ComponentPropsWithoutRef<typeof Primitive.Label> & { inset?: boolean }
@@ -67,6 +85,11 @@ export const DropdownMenuLabel = forwardRef<
 ));
 DropdownMenuLabel.displayName = Primitive.Label.displayName;
 
+/**
+ * Horizontal rule separating groups of items inside a DropdownMenuContent.
+ *
+ * @param props.className - Additional class names merged onto the separator element.
+ */
 export const DropdownMenuSeparator = forwardRef<
     ComponentRef<typeof Primitive.Separator>,
     ComponentPropsWithoutRef<typeof Primitive.Separator>

--- a/apps/admin/src/components/ui/kbd.tsx
+++ b/apps/admin/src/components/ui/kbd.tsx
@@ -2,6 +2,11 @@ import { forwardRef, type HTMLAttributes } from 'react';
 
 import { cn } from '@/utils/tailwind';
 
+/**
+ * Styled keyboard key indicator rendered as a &lt;kbd&gt; element.
+ *
+ * @param props.className - Additional class names merged onto the kbd element.
+ */
 export const Kbd = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>(({ className, ...props }, ref) => (
     <kbd
         ref={ref}

--- a/apps/admin/src/components/ui/nav-item.tsx
+++ b/apps/admin/src/components/ui/nav-item.tsx
@@ -18,6 +18,17 @@ export type NavItemProps = {
     iconOnly?: boolean;
 };
 
+/**
+ * Navigation link that highlights as active when the current pathname starts with its href.
+ * Renders as a non-interactive aria-disabled span when disabled.
+ *
+ * @param props.href - Destination route.
+ * @param props.children - Link content; typically an icon and label.
+ * @param props.className - Additional class names merged onto the element.
+ * @param props.disabled - When true, renders a non-interactive aria-disabled span.
+ * @param props.iconOnly - When true, collapses horizontal padding for icon-only rendering.
+ * @param props['aria-label'] - Accessible label, useful for icon-only items without visible text.
+ */
 export function NavItem({ href, children, className, disabled, iconOnly, 'aria-label': ariaLabel }: NavItemProps) {
     const pathname = usePathname();
 

--- a/apps/admin/src/components/ui/scroll-area.tsx
+++ b/apps/admin/src/components/ui/scroll-area.tsx
@@ -4,6 +4,12 @@ import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 import * as React from 'react';
 import { cn } from '@/utils/tailwind';
 
+/**
+ * Radix scroll area root with a custom scrollbar thumb; hides native browser scrollbars.
+ *
+ * @param props.className - Additional class names merged onto the root element.
+ * @param props.children - Content to be made scrollable.
+ */
 const ScrollArea = React.forwardRef<
     React.ElementRef<typeof ScrollAreaPrimitive.Root>,
     React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
@@ -18,6 +24,12 @@ const ScrollArea = React.forwardRef<
 ));
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
+/**
+ * Custom scrollbar track and thumb rendered inside a ScrollArea.
+ *
+ * @param props.className - Additional class names merged onto the scrollbar element.
+ * @param props.orientation - Scroll axis; defaults to 'vertical'.
+ */
 const ScrollBar = React.forwardRef<
     React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
     React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>

--- a/apps/admin/src/components/ui/separator.tsx
+++ b/apps/admin/src/components/ui/separator.tsx
@@ -5,6 +5,13 @@ import { type ComponentPropsWithoutRef, type ComponentRef, forwardRef } from 're
 
 import { cn } from '@/utils/tailwind';
 
+/**
+ * Radix separator with sensible defaults (horizontal, decorative).
+ *
+ * @param props.className - Additional class names merged onto the separator element.
+ * @param props.orientation - 'horizontal' (default, h-px w-full) or 'vertical' (h-full w-px).
+ * @param props.decorative - When true (default) the separator is hidden from the accessibility tree.
+ */
 export const Separator = forwardRef<
     ComponentRef<typeof Primitive.Root>,
     ComponentPropsWithoutRef<typeof Primitive.Root>

--- a/apps/admin/src/components/ui/tooltip.tsx
+++ b/apps/admin/src/components/ui/tooltip.tsx
@@ -9,6 +9,12 @@ export const TooltipProvider = Primitive.Provider;
 export const Tooltip = Primitive.Root;
 export const TooltipTrigger = Primitive.Trigger;
 
+/**
+ * Portal-rendered tooltip content with animated delayed-open/close transitions.
+ *
+ * @param props.className - Additional class names merged onto the content element.
+ * @param props.sideOffset - Pixel gap between the trigger and the tooltip; defaults to 4.
+ */
 export const TooltipContent = forwardRef<
     ComponentRef<typeof Primitive.Content>,
     ComponentPropsWithoutRef<typeof Primitive.Content>

--- a/apps/admin/src/hooks/use-autosave.ts
+++ b/apps/admin/src/hooks/use-autosave.ts
@@ -50,6 +50,12 @@ export type UseAutosaveResult = {
  * intentionally avoided — it is expensive for large Payload FormState objects.
  *
  * On unmount the pending timer is cancelled and NO save fires.
+ *
+ * @param options.state - Current form state; a new reference identity triggers the debounce.
+ * @param options.saveAction - Server action invoked with the current state after the debounce window.
+ * @param options.delay - Debounce window in milliseconds; defaults to 2000.
+ * @param options.disabled - When true, pending timers are cancelled and autosave is suppressed.
+ * @returns Object with isSaving, lastSavedAt, flush, and error fields.
  */
 export function useAutosave<T>({
     state,

--- a/apps/admin/src/lib/build-cms-form-state.ts
+++ b/apps/admin/src/lib/build-cms-form-state.ts
@@ -33,6 +33,13 @@ import { getFieldByPath } from 'payload';
  */
 export type BuildCmsFormStateArgs = Omit<BuildFormStateArgs, 'mockRSCs' | 'renderAllFields'>;
 
+/**
+ * Calls Payload's buildFormState with renderAllFields: false and mockRSCs: true pinned,
+ * then strips hidden editor fields and logs any mocked RSC slots.
+ *
+ * @param args - buildFormState arguments minus the pinned mockRSCs and renderAllFields flags.
+ * @returns The buildFormState result with hidden fields removed from the state map.
+ */
 export async function buildCmsFormState(args: BuildCmsFormStateArgs) {
     const result = await buildFormState({
         ...args,
@@ -155,6 +162,12 @@ function stripRowIndices(path: string): string {
         .join('.');
 }
 
+/**
+ * Deduplicates a list of MockedFieldSlot entries by path+slot and returns them sorted.
+ *
+ * @param entries - Raw mocked slot entries, potentially containing duplicates.
+ * @returns A deduplicated copy of the entries, sorted by path then slot.
+ */
 function dedupeMocks(entries: MockedFieldSlot[]): MockedFieldSlot[] {
     const seen = new Set<string>();
     const out: MockedFieldSlot[] = [];

--- a/apps/admin/src/lib/cms-actions/media-upload.ts
+++ b/apps/admin/src/lib/cms-actions/media-upload.ts
@@ -23,6 +23,13 @@ import { getAuthedPayloadCtx } from '@/lib/payload-ctx';
  * existing admin-only access predicate at the action boundary.
  *
  * Admin-only at both the route level and the action level.
+ *
+ * @param domain - Tenant domain used to resolve the Payload tenant for the media collection write.
+ * @param formData - Form data containing the 'file' (File), 'alt' (required), and optional 'caption' fields.
+ * @returns Object containing the id of the newly created media document.
+ * @throws {MissingUploadFileError} When the 'file' field is absent or not a File instance.
+ * @throws {EmptyUploadFileError} When the uploaded file has a size of zero.
+ * @throws {MissingRequiredFieldError} When the 'alt' field is absent.
  */
 export async function createMediaAction(domain: string, formData: FormData): Promise<{ id: string }> {
     const { payload, user, tenant } = await getAuthedPayloadCtx(domain);

--- a/apps/admin/src/lib/cms-server-function.ts
+++ b/apps/admin/src/lib/cms-server-function.ts
@@ -27,6 +27,9 @@ const handlerPromise: Promise<ServerFunctionClient> = (async () => {
  * the wrapper has to be a top-level `'use server'` export, which is why this
  * file exists in the app rather than the shared cms package. The actual
  * dispatch implementation lives in `@nordcom/commerce-cms/server-functions`.
+ *
+ * @param args - Dispatch arguments (action name and payload) forwarded to Payload's server-function registry.
+ * @returns The result of the matched server function handler.
  */
 export async function cmsServerFunction(args: Parameters<ServerFunctionClient>[0]) {
     const handler = await handlerPromise;

--- a/apps/admin/src/lib/get-cms-shell-props.ts
+++ b/apps/admin/src/lib/get-cms-shell-props.ts
@@ -14,6 +14,15 @@ import { getAuthedPayloadCtx } from './payload-ctx';
 const ACCEPTED_THEMES = ['dark', 'light'] as const;
 type ShellTheme = (typeof ACCEPTED_THEMES)[number];
 
+/**
+ * Resolves the Payload editor theme from config, cookie, and Sec-CH-Prefers-Color-Scheme header (in priority order).
+ *
+ * @param options.configTheme - Theme locked in payload.config.admin.theme, if any.
+ * @param options.cookiePrefix - Cookie name prefix used to derive the theme cookie key.
+ * @param options.cookies - Parsed cookie map from the current request.
+ * @param options.headers - Request headers for the Sec-CH-Prefers-Color-Scheme hint.
+ * @returns The resolved ShellTheme ('dark' or 'light').
+ */
 const resolveTheme = ({
     configTheme,
     cookiePrefix,
@@ -52,6 +61,10 @@ const resolveTheme = ({
  * access against it. Omitting `domain` returns a cross-tenant prop bag —
  * appropriate only for admin-only routes that legitimately operate outside
  * a single tenant.
+ *
+ * @param domain - Tenant domain for tenant-scoped routes; omit for cross-tenant admin routes.
+ * @param locale - Locale string forwarded to PayloadFieldShell for locale-aware fields.
+ * @returns The complete prop bag for PayloadFieldShell, excluding the children prop.
  */
 export const getCmsShellProps = cache(
     async (domain?: string, locale?: string): Promise<Omit<PayloadFieldShellProps, 'children'>> => {

--- a/apps/admin/src/lib/payload-ctx.ts
+++ b/apps/admin/src/lib/payload-ctx.ts
@@ -59,6 +59,16 @@ export type AuthedPayloadCtx = {
     } | null;
 };
 
+/**
+ * Authenticates the current NextAuth session and resolves the corresponding Payload user and tenant context.
+ *
+ * Redirects to /auth/login/ when no valid session or Payload user exists.
+ * Calls notFound() when the domain resolves to an unknown shop or tenant,
+ * or when an editor accesses a tenant they are not a member of.
+ *
+ * @param domain - Tenant domain for the request; omit on admin-only cross-tenant routes.
+ * @returns A bundle of the Payload instance, session, user, and resolved tenant (null when domain is omitted).
+ */
 export async function getAuthedPayloadCtx(domain?: string): Promise<AuthedPayloadCtx> {
     const session = await auth();
     if (!session?.user?.email) {

--- a/apps/admin/src/lib/shops-for-user.ts
+++ b/apps/admin/src/lib/shops-for-user.ts
@@ -4,7 +4,12 @@ import { Shop } from '@nordcom/commerce-db';
 
 export type ShopSwitcherEntry = { name: string; domain: string };
 
-/** Returns the shops the given user has access to. For operators (role=admin), returns all shops. */
+/**
+ * Returns the shops the given user has access to. For operators (role=admin), returns all shops.
+ *
+ * @param _userId - Currently unused; scoping by user.tenants is planned but not yet implemented.
+ * @returns Array of shop name and domain entries for the shop switcher.
+ */
 export async function getShopsForUser(_userId: string): Promise<ShopSwitcherEntry[]> {
     // TODO(shell-rework): scope by user.tenants in a follow-up. For now expose all shops.
     // TypeScript's overload picker resolves the empty-args form to the single-result

--- a/apps/admin/src/payload.config.ts
+++ b/apps/admin/src/payload.config.ts
@@ -27,6 +27,15 @@ if (!MONGODB_URI) throw new MissingEnvironmentVariableError('MONGODB_URI');
 
 const storefrontBaseUrl = process.env.STOREFRONT_BASE_URL ?? 'https://storefront.localhost';
 
+/**
+ * Constructs the storefront live-preview URL for the given tenant, collection, and document.
+ *
+ * @param tenantId - The Payload tenant id used to scope the storefront preview route.
+ * @param collection - The Payload collection slug (`pages`, `articles`, `productMetadata`, `collectionMetadata`).
+ * @param data - The document data; `slug` or `shopifyHandle` is used as the path handle.
+ * @param locale - The locale prefix for the preview URL path.
+ * @returns A fully-qualified storefront preview URL with `preview=1` and the preview secret.
+ */
 export const buildLivePreviewUrl = ({
     tenantId,
     collection,

--- a/apps/admin/src/utils/auth.adapter.ts
+++ b/apps/admin/src/utils/auth.adapter.ts
@@ -15,6 +15,15 @@ const adapterCatch = (op: string, error: unknown): null => {
     throw error;
 };
 
+/**
+ * Constructs an Auth.js adapter backed by the commerce-db User, Session, and Identity models.
+ *
+ * Returns null (not throws) for "not found" DB results to signal Auth.js to create a new resource;
+ * re-throws all other errors so infrastructure failures surface at the error page rather than
+ * silently triggering a duplicate-resource path.
+ *
+ * @returns An Adapter object conforming to the Auth.js adapter interface.
+ */
 export function AuthAdapter(): Adapter {
     return {
         async getUser(id) {

--- a/apps/admin/src/utils/domains.ts
+++ b/apps/admin/src/utils/domains.ts
@@ -12,6 +12,13 @@
 const isProductionRuntime = process.env.NODE_ENV === 'production' && process.env.VERCEL_ENV !== 'preview';
 const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build';
 
+/**
+ * Reads an env var by name and returns it, or logs an error in production and returns the fallback.
+ *
+ * @param envName - The environment variable name to read.
+ * @param fallback - The default value returned when the env var is absent or empty.
+ * @returns The resolved hostname string.
+ */
 const requireOrFallback = (envName: 'ADMIN_DOMAIN' | 'LANDING_DOMAIN', fallback: string): string => {
     const value = process.env[envName];
     if (value && value.length > 0) return value;
@@ -27,10 +34,10 @@ const ADMIN_HOSTNAME = requireOrFallback('ADMIN_DOMAIN', 'admin.localhost');
 const LANDING_HOSTNAME = requireOrFallback('LANDING_DOMAIN', 'landing.localhost');
 
 // Portless serves HTTPS for .localhost URLs in dev, so the protocol is always https.
-// biome-ignore lint/correctness/noUnusedFunctionParameters: Preserve argument name.
-const protocolFor = (hostname: string) => 'https' as const;
+/** Returns the protocol string for the resolved admin URL; always `"https"` since portless serves HTTPS for all environments. @returns The literal string `"https"`. */
+const protocolFor = () => 'https' as const;
 
 export const ADMIN_DOMAIN = ADMIN_HOSTNAME;
 export const LANDING_DOMAIN = LANDING_HOSTNAME;
-export const ADMIN_URL = `${protocolFor(ADMIN_HOSTNAME)}://${ADMIN_HOSTNAME}`;
-export const LANDING_URL = `${protocolFor(LANDING_HOSTNAME)}://${LANDING_HOSTNAME}`;
+export const ADMIN_URL = `${protocolFor()}://${ADMIN_HOSTNAME}`;
+export const LANDING_URL = `${protocolFor()}://${LANDING_HOSTNAME}`;

--- a/apps/admin/src/utils/fetchers.ts
+++ b/apps/admin/src/utils/fetchers.ts
@@ -2,6 +2,12 @@ import 'server-only';
 
 import { Shop } from '@nordcom/commerce-db';
 
+/**
+ * Fetches the shops accessible to the given user for use in the admin shell's shop switcher.
+ *
+ * @param userId - The authenticated user's id used to scope the shop list.
+ * @returns Array of shops the user can access, sorted by creation date descending.
+ */
 export async function getShopsForUser(userId: string) {
     // `sort` was a Mongoose-era option; Phase 2's payload.local-backed
     // `findByCollaborator` doesn't take options. The result is sorted by

--- a/apps/admin/src/utils/tailwind.ts
+++ b/apps/admin/src/utils/tailwind.ts
@@ -1,6 +1,12 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+/**
+ * Merges class names using clsx and resolves Tailwind conflicts with tailwind-merge.
+ *
+ * @param inputs - Class values to merge; accepts strings, arrays, objects, and conditionals.
+ * @returns A single deduplicated Tailwind class string.
+ */
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }

--- a/apps/admin/src/utils/test/react.tsx
+++ b/apps/admin/src/utils/test/react.tsx
@@ -5,12 +5,26 @@ import { queries, render, within } from '@testing-library/react';
 import { SessionProvider } from 'next-auth/react';
 import type { ReactElement, ReactNode } from 'react';
 
+/** Wraps children in a NextAuth SessionProvider with a null session for isolated test renders. @param props.children - The component tree to wrap. */
 const Providers = ({ children }: { children: ReactNode }) => (
     <SessionProvider session={null}>{children}</SessionProvider>
 );
 
 const customScreen = within(document.body, queries);
+/**
+ * Scopes Testing Library queries to a given element using the standard query set.
+ *
+ * @param element - The element to scope queries to.
+ * @returns A queries object bound to the provided element.
+ */
 const customWithin = (element: ReactElement) => within(element as unknown as HTMLElement, queries);
+/**
+ * Renders a component wrapped in the test SessionProvider with null session.
+ *
+ * @param ui - The React element to render.
+ * @param options - Optional render options forwarded to Testing Library render, excluding queries.
+ * @returns The Testing Library render result.
+ */
 const customRender = (ui: Parameters<typeof render>[0], options?: Omit<Parameters<typeof render>[1], 'queries'>) =>
     render(ui, { wrapper: Providers, ...options });
 


### PR DESCRIPTION
Part of the JSDoc coverage retrofit campaign.

Adds Tier-2 JSDoc blocks (1-line purpose + `@param`/`@returns`/`@throws` where applicable) to every exported and internal function and React component in `apps/admin` that was missing coverage.

- 55 files touched, 475 lines added
- No `@example` blocks (apps are Tier 2)
- Server actions include mandatory `\@throws`
- Next.js framework files (`page.tsx`, `layout.tsx`, `route.ts`, etc.) excluded
- Auto-generated `_generated/` files excluded
- Also removes a pre-existing `biome-ignore` suppression in `utils/domains.ts` by dropping the genuinely unused `hostname` parameter from `protocolFor()`, consistent with the no-suppress coding convention

Typecheck and Biome lint pass cleanly.