### PR TITLE
docs(storefront-components): backfill jsdoc on components/

### DIFF
--- a/apps/storefront/src/components/actionable/button.tsx
+++ b/apps/storefront/src/components/actionable/button.tsx
@@ -14,6 +14,15 @@ export type ButtonProps<ComponentGeneric extends ElementType> = ButtonPropsBase<
         ? Omit<ComponentPropsWithoutRef<ComponentGeneric>, keyof ButtonPropsBase<ComponentGeneric>>
         : ComponentPropsWithoutRef<ComponentGeneric>);
 
+/**
+ * Polymorphic button with optional primary styling.
+ *
+ * @param props.as - Element or component to render; defaults to `button`.
+ * @param props.styled - When `true` (default), applies full primary button styles.
+ * @param props.disabled - Prevents interaction and dims the element when `true`.
+ * @param props.className - Additional class names.
+ * @returns The rendered button element.
+ */
 export const Button = <ComponentGeneric extends ElementType = 'button'>({
     as,
     styled = true,

--- a/apps/storefront/src/components/actionable/export-cart-button.tsx
+++ b/apps/storefront/src/components/actionable/export-cart-button.tsx
@@ -12,6 +12,12 @@ import { getTranslations, type LocaleDictionary } from '@/utils/locale';
 type ExportCartButtonProps = {
     i18n: LocaleDictionary;
 };
+/**
+ * Button that exports the current cart lines to a CSV file.
+ *
+ * @param props.i18n - Locale dictionary for translated button label.
+ * @returns The export button, or `null` when the cart is empty.
+ */
 export function ExportCartButton({ i18n }: ExportCartButtonProps) {
     const [busy, setBusy] = useState(false);
     const { shop } = useShop();

--- a/apps/storefront/src/components/actionable/filter-values.tsx
+++ b/apps/storefront/src/components/actionable/filter-values.tsx
@@ -6,6 +6,14 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import Link from '@/components/link';
 import { cn } from '@/utils/tailwind';
 
+/**
+ * Renders the interactive value list for a single Shopify collection filter.
+ *
+ * @param props.id - Filter identifier used as the URL query key.
+ * @param props.type - Shopify filter type (`LIST`, `BOOLEAN`, `PRICE_RANGE`, etc.).
+ * @param props.values - Available filter values to render.
+ * @returns The filter value controls, or `null` when `values` is empty or the type is unsupported.
+ */
 export function FilterValues({ id: filterId, type, values }: Pick<Filter, 'type' | 'values' | 'id'>) {
     const pathname = usePathname();
     const baseUrl = `${pathname}`;

--- a/apps/storefront/src/components/actionable/filters.tsx
+++ b/apps/storefront/src/components/actionable/filters.tsx
@@ -10,6 +10,13 @@ export type FiltersProps = {
     filters: Filter[];
     disabled?: boolean;
 } & Omit<HTMLProps<HTMLDivElement>, 'children'>;
+/**
+ * Renders a list of Shopify collection filters as labeled card groups.
+ *
+ * @param props.filters - Array of Shopify `Filter` objects to display.
+ * @param props.disabled - When `true`, dims and disables all filter interactions.
+ * @returns The filters section, or `null` when `filters` is empty.
+ */
 export function Filters({ filters, disabled = false, className, ...props }: FiltersProps) {
     if (filters.length <= 0) {
         return null;

--- a/apps/storefront/src/components/actionable/input.tsx
+++ b/apps/storefront/src/components/actionable/input.tsx
@@ -5,6 +5,14 @@ export type InputProps<T extends ElementType = 'input'> = {
     as?: T;
     ref?: RefObject<HTMLInputElement | null>;
 } & ComponentProps<T>;
+/**
+ * Polymorphic single-line input with consistent focus and disabled styles.
+ *
+ * @param props.as - Element or component to render; defaults to `input`.
+ * @param props.ref - Forwarded ref for the underlying `HTMLInputElement`.
+ * @param props.className - Additional class names.
+ * @returns The rendered input element.
+ */
 const Input = <T extends ElementType = 'input'>({
     as: Tag = 'input' as T,
     ref,
@@ -31,6 +39,14 @@ export type MultilineInputProps<T extends ElementType> = {
 
     children: ReactNode;
 } & ComponentProps<T>;
+/**
+ * Multiline text input (textarea by default) with consistent styling.
+ *
+ * @param props.as - Element or component to render; defaults to `textarea`.
+ * @param props.children - Content rendered inside the element.
+ * @param props.className - Additional class names.
+ * @returns The rendered textarea element.
+ */
 const MultilineInput = <T extends ElementType>({
     as: Tag = 'textarea' as T,
     children,

--- a/apps/storefront/src/components/actionable/login-button.tsx
+++ b/apps/storefront/src/components/actionable/login-button.tsx
@@ -9,6 +9,12 @@ import { capitalize, getTranslations } from '@/utils/locale';
 export type LoginButtonProps = {
     i18n: LocaleDictionary;
 };
+/**
+ * Icon button that initiates Shopify OAuth login via NextAuth.
+ *
+ * @param props.i18n - Locale dictionary for the accessible button title.
+ * @returns The login button element.
+ */
 export function LoginButton({ i18n }: LoginButtonProps) {
     const { t } = getTranslations('common', i18n);
 

--- a/apps/storefront/src/components/actionable/pagination.tsx
+++ b/apps/storefront/src/components/actionable/pagination.tsx
@@ -23,6 +23,15 @@ export type PaginationProps = ComponentProps<'nav'> & {
     knownLastPage?: number;
     morePagesAfterKnownLastPage?: boolean;
 };
+/**
+ * URL-driven pagination nav that builds page links from the current search params.
+ *
+ * @param props.i18n - Locale dictionary for previous/next labels.
+ * @param props.knownFirstPage - First page number; defaults to `1`.
+ * @param props.knownLastPage - Last known page number; defaults to `1`.
+ * @param props.morePagesAfterKnownLastPage - Shows an ellipsis indicator when further pages may exist.
+ * @returns The pagination nav, or `null` when there is only one page.
+ */
 export function Pagination({
     i18n,
     knownFirstPage = 1,

--- a/apps/storefront/src/components/analytics-provider.tsx
+++ b/apps/storefront/src/components/analytics-provider.tsx
@@ -18,6 +18,16 @@ export type AnalyticsProviderProps = {
     children: ReactNode;
     enableThirdParty?: boolean;
 };
+/**
+ * Wraps children with Vercel Analytics, Speed Insights, and optional third-party
+ * scripts (Google Tag Manager) deferred by 6.5 s to avoid blocking the critical path.
+ *
+ * @param props.shop - Shop record used to resolve third-party integration IDs.
+ * @param props.hostname - Request hostname; preview environments and crawlers suppress third-party scripts.
+ * @param props.children - Component subtree to wrap.
+ * @param props.enableThirdParty - Opt out of third-party scripts entirely when `false`.
+ * @returns The wrapped subtree inside an error boundary.
+ */
 export const AnalyticsProvider = ({ shop, hostname, children, enableThirdParty = true }: AnalyticsProviderProps) => {
     const vercelAnalyticsMode = BuildConfig.environment !== 'test' ? BuildConfig.environment : 'auto';
 

--- a/apps/storefront/src/components/cart/cart-coupons.tsx
+++ b/apps/storefront/src/components/cart/cart-coupons.tsx
@@ -7,6 +7,11 @@ import { Button } from '@/components/actionable/button';
 import { Label } from '@/components/typography/label';
 import { cn } from '@/utils/tailwind';
 
+/**
+ * Displays active discount codes on the cart and provides a button to remove each one.
+ *
+ * @returns The coupon list section, or `null` when the cart is not ready or has no active discounts.
+ */
 const CartCoupons = ({}) => {
     const { discountCodes } = useCartMeta();
     const { cartReady } = useCartStatus();

--- a/apps/storefront/src/components/cart/cart-line.tsx
+++ b/apps/storefront/src/components/cart/cart-line.tsx
@@ -49,6 +49,14 @@ interface CartLineProps {
     i18n: LocaleDictionary;
     data: ShopifyCartLine;
 }
+/**
+ * Renders a single cart line with image, title, variant selector popover,
+ * quantity stepper, and line-total pricing.
+ *
+ * @param props.i18n - Locale dictionary for translated labels.
+ * @param props.data - Shopify cart line data from the cart provider.
+ * @returns The cart line card, or `null` when the product or variant cannot be resolved.
+ */
 const CartLine = ({ i18n, data: line }: CartLineProps) => {
     const { addLine, updateLine, removeLine } = useCartActions();
     const { cartReady, status } = useCartStatus();
@@ -82,6 +90,13 @@ const CartLine = ({ i18n, data: line }: CartLineProps) => {
     // `compare` at 0 — guard the divide so we don't render an `Infinity% off`
     // strikethrough. Also clamp to [0,100] so a negative auto-discount
     // allocation (current > compare) doesn't produce a confusing negative.
+    /**
+     * Computes a discount percentage clamped to [0, 100].
+     *
+     * @param compareStr - Original (compare-at) price amount string.
+     * @param currentStr - Actual line total amount string.
+     * @returns Integer discount percentage, or `0` when the math is not finite.
+     */
     const computeDiscount = (compareStr: string | undefined, currentStr: string | undefined): number => {
         const compare = safeParseFloat(0, compareStr);
         const current = safeParseFloat(0, currentStr);

--- a/apps/storefront/src/components/cart/cart-lines.tsx
+++ b/apps/storefront/src/components/cart/cart-lines.tsx
@@ -12,6 +12,12 @@ import { getTranslations, type LocaleDictionary } from '@/utils/locale';
 type CartContentProps = {
     i18n: LocaleDictionary;
 };
+/**
+ * Renders all lines in the current cart with clear-cart and CSV export controls.
+ *
+ * @param props.i18n - Locale dictionary for translated labels.
+ * @returns The cart line list, a skeleton while loading, or an empty-state label.
+ */
 const CartLines = ({ i18n }: CartContentProps) => {
     const { t: tCart } = getTranslations('cart', i18n);
 

--- a/apps/storefront/src/components/cart/cart-note.tsx
+++ b/apps/storefront/src/components/cart/cart-note.tsx
@@ -6,6 +6,12 @@ import type { AppCartCaps } from '@/cart/caps';
 import { MultilineInput } from '@/components/actionable/input';
 import { getTranslations, type LocaleDictionary } from '@/utils/locale';
 
+/**
+ * Controlled textarea that persists a note on the Shopify cart on blur.
+ *
+ * @param props.i18n - Locale dictionary for the placeholder text.
+ * @returns The cart note textarea.
+ */
 const CartNote = ({ i18n }: { i18n: LocaleDictionary }) => {
     const { t } = getTranslations('cart', i18n);
     const { note } = useCartMeta();

--- a/apps/storefront/src/components/cart/cart-summary.tsx
+++ b/apps/storefront/src/components/cart/cart-summary.tsx
@@ -42,6 +42,17 @@ type CartSummaryProps = {
     children?: ReactNode;
     paymentMethods?: ReactNode;
 };
+/**
+ * Sticky order-summary sidebar with subtotal, discount rows, a checkout button,
+ * payment-method logos, and the cart note field.
+ *
+ * @param props.shop - Shop record (currently unused; reserved for free-shipping config).
+ * @param props.onCheckout - Callback invoked when the checkout button is clicked.
+ * @param props.i18n - Locale dictionary for translated labels.
+ * @param props.children - Optional slot rendered above the order summary section.
+ * @param props.paymentMethods - Optional payment method icons rendered in the trust footer.
+ * @returns The cart summary panel.
+ */
 const CartSummary = ({ onCheckout, i18n, children, paymentMethods }: CartSummaryProps) => {
     const { t } = getTranslations('cart', i18n);
     const { status, cartReady } = useCartStatus();

--- a/apps/storefront/src/components/footer/footer-content.tsx
+++ b/apps/storefront/src/components/footer/footer-content.tsx
@@ -14,6 +14,15 @@ export type FooterContentProps = {
     shop: OnlineShop;
 };
 
+/**
+ * Async footer sub-section that fetches and renders accepted payment methods
+ * and the current locale flag link.
+ *
+ * @param props.locale - Active locale used to display the correct country flag.
+ * @param props.i18n - Locale dictionary for translated aria labels.
+ * @param props.shop - Shop record forwarded to `AcceptedPaymentMethods`.
+ * @returns The two-column footer content section.
+ */
 const FooterContent = async ({ locale, i18n, shop }: FooterContentProps) => {
     const { t } = getTranslations('common', i18n);
 

--- a/apps/storefront/src/components/footer/footer.tsx
+++ b/apps/storefront/src/components/footer/footer.tsx
@@ -28,6 +28,7 @@ type Social = NonNullable<FooterDoc['social']>[number];
 // `lucide-react` v1+ ships no brand glyphs, so inline SVGs keep the footer
 // self-contained without pulling in another icon package.
 type SocialIconProps = { className?: string };
+/** Instagram brand icon as an inline SVG. */
 const InstagramIcon = ({ className }: SocialIconProps) => (
     <svg
         viewBox="0 0 24 24"
@@ -44,26 +45,31 @@ const InstagramIcon = ({ className }: SocialIconProps) => (
         <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
     </svg>
 );
+/** Facebook brand icon as an inline SVG. */
 const FacebookIcon = ({ className }: SocialIconProps) => (
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden={true} className={className}>
         <path d="M22 12a10 10 0 1 0-11.56 9.88v-6.99H7.9V12h2.54V9.8c0-2.51 1.49-3.9 3.78-3.9 1.1 0 2.24.2 2.24.2v2.46h-1.26c-1.24 0-1.63.77-1.63 1.56V12h2.78l-.44 2.89h-2.34v6.99A10 10 0 0 0 22 12z" />
     </svg>
 );
+/** YouTube brand icon as an inline SVG. */
 const YoutubeIcon = ({ className }: SocialIconProps) => (
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden={true} className={className}>
         <path d="M23.5 6.2a3 3 0 0 0-2.1-2.12C19.6 3.5 12 3.5 12 3.5s-7.6 0-9.4.58A3 3 0 0 0 .5 6.2 31.4 31.4 0 0 0 0 12a31.4 31.4 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.12C4.4 20.5 12 20.5 12 20.5s7.6 0 9.4-.58a3 3 0 0 0 2.1-2.12A31.4 31.4 0 0 0 24 12a31.4 31.4 0 0 0-.5-5.8zM9.75 15.5v-7l6.5 3.5-6.5 3.5z" />
     </svg>
 );
+/** LinkedIn brand icon as an inline SVG. */
 const LinkedinIcon = ({ className }: SocialIconProps) => (
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden={true} className={className}>
         <path d="M19 0H5a5 5 0 0 0-5 5v14a5 5 0 0 0 5 5h14a5 5 0 0 0 5-5V5a5 5 0 0 0-5-5zM8 19H5V8h3v11zM6.5 6.7A1.74 1.74 0 1 1 8.24 5 1.74 1.74 0 0 1 6.5 6.7zM20 19h-3v-5.6c0-3.36-4-3.1-4 0V19h-3V8h3v1.76c1.4-2.6 7-2.8 7 2.48V19z" />
     </svg>
 );
+/** X (formerly Twitter) brand icon as an inline SVG. */
 const TwitterXIcon = ({ className }: SocialIconProps) => (
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden={true} className={className}>
         <path d="M18.244 2H21.5l-7.43 8.49L23 22h-6.91l-4.71-6.18L5.94 22H2.68l7.92-9.05L1.7 2h7.05l4.26 5.66L18.24 2zm-1.21 18h1.86L7.04 4H5.04l11.99 16z" />
     </svg>
 );
+/** TikTok brand icon as an inline SVG. */
 const TiktokIcon = ({ className }: SocialIconProps) => (
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden={true} className={className}>
         <path d="M21 8.78a8.83 8.83 0 0 1-5.18-1.66v7.45a6.43 6.43 0 1 1-5.55-6.37v3.06a3.39 3.39 0 1 0 2.49 3.27V2h3.06a5.76 5.76 0 0 0 5.18 5.16V8.78z" />
@@ -85,6 +91,15 @@ export type FooterProps = {
     i18n: LocaleDictionary;
 };
 
+/**
+ * Async site footer fetching CMS data and rendering logo, navigation sections,
+ * social links, legal links, copyright, and payment/locale content.
+ *
+ * @param props.shop - Shop record providing logo and name.
+ * @param props.locale - Active locale forwarded to link resolvers.
+ * @param props.i18n - Locale dictionary forwarded to `FooterContent`.
+ * @returns The full-width footer element.
+ */
 const Footer = async ({ shop, locale, i18n }: FooterProps) => {
     const footer = await FooterApi({ shop, locale });
     const { logo } = shop.design.header;
@@ -157,6 +172,13 @@ const Footer = async ({ shop, locale, i18n }: FooterProps) => {
     );
 };
 
+/**
+ * Renders a single CMS-defined footer navigation section with its title and links.
+ *
+ * @param props.section - CMS footer section data containing title and link array.
+ * @param props.locale - Active locale forwarded to `resolveLink`.
+ * @returns The section block, or `null` when it has no links.
+ */
 function FooterSection({ section, locale }: { section: Section; locale: Locale }) {
     const links: SectionLinks = section.links ?? [];
     if (links.length === 0) return null;
@@ -172,6 +194,13 @@ function FooterSection({ section, locale }: { section: Section; locale: Locale }
     );
 }
 
+/**
+ * Renders a single navigational link inside a `FooterSection`.
+ *
+ * @param props.item - CMS section link entry.
+ * @param props.locale - Active locale for URL resolution.
+ * @returns The anchor element, or `null` when the link cannot be resolved.
+ */
 function FooterLinkAnchor({ item, locale }: { item: SectionLink; locale: Locale }) {
     if (!item.link) return null;
     const href = resolveLink(item.link as never, { locale: { code: locale.code } });
@@ -187,6 +216,13 @@ function FooterLinkAnchor({ item, locale }: { item: SectionLink; locale: Locale 
     );
 }
 
+/**
+ * Renders a muted legal page link in the footer's bottom legal strip.
+ *
+ * @param props.item - CMS legal link entry.
+ * @param props.locale - Active locale for URL resolution.
+ * @returns The anchor element, or `null` when the link cannot be resolved.
+ */
 function FooterLegalLink({ item, locale }: { item: LegalLink; locale: Locale }) {
     if (!item.link) return null;
     const href = resolveLink(item.link as never, { locale: { code: locale.code } });

--- a/apps/storefront/src/components/geo-redirect.tsx
+++ b/apps/storefront/src/components/geo-redirect.tsx
@@ -18,9 +18,17 @@ import { cn } from '@/utils/tailwind';
 
 const DISMISSED_KEY = 'geo-redirect-banner-dismissed';
 
+/** No-op unsubscribe factory required by `useSyncExternalStore` for snapshot-only stores. */
 const subscribeToNothing = () => () => {};
+/** Returns the browser's primary language code in lowercase. */
 const getNavigatorLanguage = () => (navigator.language.split('-').at(0) || 'en').toLowerCase();
+/** Returns the current `navigator.userAgent` string. */
 const getUserAgent = () => navigator.userAgent;
+/**
+ * Reads and validates the geo-redirect banner dismissal timestamp from localStorage.
+ *
+ * @returns The stored dismissal timestamp, or `null` when absent, invalid, or older than 24 hours.
+ */
 const readStoredDismissed = (): number | null => {
     if (typeof localStorage === 'undefined') {
         return null;
@@ -52,6 +60,15 @@ export type GeoRedirectProps = {
     shop: OnlineShop;
     i18n: LocaleDictionary;
 };
+/**
+ * Sticky banner that prompts the visitor to switch to the locale matching their IP geolocation.
+ *
+ * @param props.countries - Available countries used to match the detected IP country.
+ * @param props.locale - Current active locale.
+ * @param props.shop - Shop record used to fetch the target locale dictionary.
+ * @param props.i18n - Fallback locale dictionary until the target locale dictionary loads.
+ * @returns The redirect banner, or `null` when dismissed, already matching, or a crawler.
+ */
 export function GeoRedirect({ countries, locale, shop, i18n: defaultI18n }: GeoRedirectProps) {
     const [closed, setClosed] = useState(false);
     const [i18n, setI18n] = useState<LocaleDictionary | undefined>();

--- a/apps/storefront/src/components/header/cart-button.tsx
+++ b/apps/storefront/src/components/header/cart-button.tsx
@@ -11,6 +11,13 @@ export type CartButtonProps = {
     locale: Locale;
     i18n: LocaleDictionary;
 };
+/**
+ * Header cart button showing item count and linking to the cart page.
+ *
+ * @param props.locale - Active locale forwarded to the cart link.
+ * @param props.i18n - Locale dictionary for the cart link title.
+ * @returns The cart link button with optional item count badge.
+ */
 const CartButton = ({ locale, i18n }: CartButtonProps) => {
     const { t } = getTranslations('cart', i18n);
     const totalQuantity = useCartCount();

--- a/apps/storefront/src/components/header/header-account-section.tsx
+++ b/apps/storefront/src/components/header/header-account-section.tsx
@@ -16,6 +16,14 @@ export type HeaderAccountSectionProps = {
     locale: Locale;
     i18n: LocaleDictionary;
 } & Omit<HTMLProps<HTMLDivElement>, 'children'>;
+/**
+ * Async server component rendering the account area in the header.
+ *
+ * @param props.shop - Shop record used to evaluate the accounts feature flag.
+ * @param props.i18n - Locale dictionary for label translations.
+ * @param props.className - Additional CSS class names.
+ * @returns Login button when unauthenticated, avatar link when authenticated, or `null` when accounts are disabled.
+ */
 export async function HeaderAccountSection({ shop, i18n, className, ...props }: HeaderAccountSectionProps) {
     // Inside cached subtree → .evaluate(shop). Trade-offs in defineFlag JSDoc.
     const enabled = accountsEnabled.evaluate(shop);

--- a/apps/storefront/src/components/header/header-menu.tsx
+++ b/apps/storefront/src/components/header/header-menu.tsx
@@ -46,6 +46,13 @@ const HOVER_CLOSE_DELAY_MS = 150;
 const COLUMN_DIVIDER_CLASSES =
     "md:[&:not(:last-child)]:after:content-[''] md:[&:not(:last-child)]:after:absolute md:[&:not(:last-child)]:after:top-0 md:[&:not(:last-child)]:after:bottom-0 md:[&:not(:last-child)]:after:-right-[calc(var(--header-column-gap-x)/2)] md:[&:not(:last-child)]:after:w-px md:[&:not(:last-child)]:after:bg-[var(--header-divider-color)]";
 
+/**
+ * Accessible trigger button that opens a portaled mega-menu panel for a nav item.
+ *
+ * @param props.item - CMS nav item providing label, link, and nested children.
+ * @param props.locale - Active locale forwarded to link resolvers inside the panel.
+ * @returns The trigger button and portaled mega-menu panel.
+ */
 export function HeaderMenuTrigger({ item, locale }: { item: NavItem; locale: { code: string } }) {
     const menuId = useId();
     const [open, setOpen] = useState(false);
@@ -277,6 +284,12 @@ const KNOWN_VARIANTS: ReadonlySet<Variant> = new Set<Variant>(HEADER_VARIANTS);
 
 const warnedUnknownVariants = new Set<string>();
 
+/**
+ * Maps an unknown variant value to a valid `HeaderVariant`, warning once in development for unknowns.
+ *
+ * @param raw - Raw variant value from the CMS.
+ * @returns The validated variant name, falling back to `'editorial-columns'`.
+ */
 const resolveVariant = (raw: unknown): Variant => {
     if (typeof raw === 'string' && KNOWN_VARIANTS.has(raw as Variant)) return raw as Variant;
     if (raw != null && process.env.NODE_ENV !== 'production') {
@@ -289,6 +302,13 @@ const resolveVariant = (raw: unknown): Variant => {
     return 'editorial-columns';
 };
 
+/**
+ * Dispatches to the correct mega-menu layout based on the nav item's `variant` field.
+ *
+ * @param props.item - CMS nav item with a `variant` field and nested `items`.
+ * @param props.locale - Active locale forwarded to link resolvers.
+ * @returns The variant-specific panel element.
+ */
 function MegaMenuPanel({ item, locale }: { item: NavItem; locale: { code: string } }) {
     const variant = resolveVariant(item.variant);
     return (
@@ -300,6 +320,13 @@ function MegaMenuPanel({ item, locale }: { item: NavItem; locale: { code: string
     );
 }
 
+/**
+ * Multi-column editorial panel for the `editorial-columns` nav variant.
+ *
+ * @param props.item - CMS nav item whose `items` become individual columns.
+ * @param props.locale - Active locale forwarded to link resolvers.
+ * @returns The column grid, or `null` when there are no items.
+ */
 function EditorialColumnsPanel({ item, locale }: { item: NavItem; locale: { code: string } }) {
     const items = (item.items ?? []) as RecursiveNavItem[];
     if (items.length === 0) return null;
@@ -327,6 +354,14 @@ function EditorialColumnsPanel({ item, locale }: { item: NavItem; locale: { code
     );
 }
 
+/**
+ * Single editorial column with an optional image, eyebrow link, description, and sub-links.
+ *
+ * @param props.item - Nav item providing link, image, description, and child items.
+ * @param props.locale - Active locale forwarded to link resolvers.
+ * @param props.index - Column index used to stagger the entrance animation delay.
+ * @returns The column element, or `null` when there is no label and no children.
+ */
 function EditorialColumn({ item, locale, index }: { item: RecursiveNavItem; locale: { code: string }; index: number }) {
     const link = item.link;
     const label = link?.label ?? null;
@@ -401,6 +436,14 @@ function EditorialColumn({ item, locale, index }: { item: RecursiveNavItem; loca
     );
 }
 
+/**
+ * Leaf sub-link inside an editorial column; renders as an anchor or plain span when the URL cannot be resolved.
+ *
+ * @param props.item - Nav item providing the link data.
+ * @param props.locale - Active locale forwarded to the link resolver.
+ * @param props.size - Visual size variant controlling padding and font size.
+ * @returns The styled link element, or `null` when no label is present.
+ */
 function EditorialSublink({
     item,
     locale,
@@ -437,6 +480,13 @@ function EditorialSublink({
     );
 }
 
+/**
+ * Single-column compact link list for the `compact-list` nav variant.
+ *
+ * @param props.item - CMS nav item whose `items` become list entries.
+ * @param props.locale - Active locale forwarded to link resolvers.
+ * @returns The list element, or `null` when there are no items.
+ */
 function CompactListPanel({ item, locale }: { item: NavItem; locale: { code: string } }) {
     const items = (item.items ?? []) as RecursiveNavItem[];
     if (items.length === 0) return null;
@@ -453,6 +503,13 @@ function CompactListPanel({ item, locale }: { item: NavItem; locale: { code: str
     );
 }
 
+/**
+ * Single row in a `CompactListPanel`; renders as an anchor or span when the URL cannot be resolved.
+ *
+ * @param props.item - Nav item providing the link data.
+ * @param props.locale - Active locale forwarded to the link resolver.
+ * @returns The styled link element, or `null` when no label is present.
+ */
 function CompactListItem({ item, locale }: { item: RecursiveNavItem; locale: { code: string } }) {
     const link = item.link;
     const label = link?.label ?? null;
@@ -475,6 +532,13 @@ function CompactListItem({ item, locale }: { item: RecursiveNavItem; locale: { c
     );
 }
 
+/**
+ * Featured-promo panel showing a hero image block and a secondary link list side by side.
+ *
+ * @param props.item - CMS nav item whose first child becomes the hero and the rest become list items.
+ * @param props.locale - Active locale forwarded to link resolvers.
+ * @returns The promo layout, or `null` when there are no items.
+ */
 function FeaturedPromoPanel({ item, locale }: { item: NavItem; locale: { code: string } }) {
     const items = (item.items ?? []) as RecursiveNavItem[];
     if (items.length === 0) return null;
@@ -506,6 +570,13 @@ function FeaturedPromoPanel({ item, locale }: { item: NavItem; locale: { code: s
     );
 }
 
+/**
+ * Hero image or color swatch with title, description, and CTA inside a featured-promo panel.
+ *
+ * @param props.item - Nav item providing image, label, description, background color, and link.
+ * @param props.locale - Active locale forwarded to the link resolver.
+ * @returns The hero block, optionally wrapped in an anchor.
+ */
 function FeaturedHero({ item, locale }: { item: RecursiveNavItem; locale: { code: string } }) {
     const link = item.link;
     const label = link?.label ?? null;

--- a/apps/storefront/src/components/header/header-navigation.tsx
+++ b/apps/storefront/src/components/header/header-navigation.tsx
@@ -16,6 +16,13 @@ export type HeaderNavigationProps = {
     locale: Locale;
 } & Omit<HTMLProps<HTMLDivElement>, 'className' | 'children'>;
 
+/**
+ * Horizontally scrollable server-rendered top navigation bar.
+ *
+ * @param props.items - CMS nav items rendered as top-level links or menu triggers.
+ * @param props.locale - Active locale forwarded to `HeaderMenuTrigger` and link resolvers.
+ * @returns The `<nav>` element, or `null` when `items` is empty.
+ */
 export function HeaderNavigation({ items, locale, ...rest }: HeaderNavigationProps) {
     if (!items?.length) return null;
 
@@ -40,6 +47,13 @@ export function HeaderNavigation({ items, locale, ...rest }: HeaderNavigationPro
 
 HeaderNavigation.displayName = 'Nordcom.Header.HeaderNavigation';
 
+/**
+ * Single top-level nav entry that renders as a `HeaderMenuTrigger` when it has children, or a plain link otherwise.
+ *
+ * @param props.item - CMS nav item providing link, children, and metadata.
+ * @param props.locale - Active locale forwarded to link resolvers.
+ * @returns The trigger or anchor element, or `null` when the item has no link.
+ */
 function HeaderNavTopItem({ item, locale }: { item: NavItem; locale: Locale }) {
     const link = item.link;
     if (!link) return null;

--- a/apps/storefront/src/components/header/header-provider.tsx
+++ b/apps/storefront/src/components/header/header-provider.tsx
@@ -36,6 +36,13 @@ export type HeaderProviderProps = {
 // so its uncached reads must not block the fallback path. Render children
 // with a noop context during prerender; the real provider takes over after
 // hydration.
+/**
+ * Top-level provider wrapping the header context in a Suspense boundary to prevent prerender blocking.
+ *
+ * @param props.children - Subtree that consumes `HeaderContext`.
+ * @param props.loaderColor - Primary color forwarded to the `NextTopLoader` progress bar.
+ * @returns The Suspense-wrapped header context provider.
+ */
 export const HeaderProvider = ({ children, loaderColor }: HeaderProviderProps) => {
     return (
         <Suspense fallback={<HeaderContext.Provider value={NOOP_HEADER_VALUE}>{children}</HeaderContext.Provider>}>
@@ -44,6 +51,13 @@ export const HeaderProvider = ({ children, loaderColor }: HeaderProviderProps) =
     );
 };
 
+/**
+ * Inner provider that tracks scroll position, resets menu state on route change, and mounts the route-progress loader.
+ *
+ * @param props.children - Subtree that consumes `HeaderContext`.
+ * @param props.loaderColor - Primary color forwarded to `NextTopLoader`.
+ * @returns The context provider element with children and top-loader.
+ */
 const HeaderProviderInner = ({ children, loaderColor }: HeaderProviderProps) => {
     const pathname = usePathname();
     const _searchParams = useSearchParams();
@@ -100,6 +114,12 @@ const HeaderProviderInner = ({ children, loaderColor }: HeaderProviderProps) => 
     );
 };
 
+/**
+ * Returns the current header menu context value.
+ *
+ * @throws {MissingContextProviderError} When called outside a `HeaderProvider`.
+ * @returns The `HeaderContextValue` from the nearest provider.
+ */
 export const useHeaderMenu = (): HeaderContextValue => {
     const context = useContext(HeaderContext);
     if (!context) {

--- a/apps/storefront/src/components/header/header.tsx
+++ b/apps/storefront/src/components/header/header.tsx
@@ -18,6 +18,14 @@ export type HeaderProps = {
     i18n: LocaleDictionary;
 } & Omit<HTMLProps<HTMLDivElement>, 'className'>;
 
+/**
+ * Async server component rendering the sticky site header with logo, search, account, cart, and navigation.
+ *
+ * @param props.domain - Shop domain used to resolve the shop record and CMS header config.
+ * @param props.locale - Active locale forwarded to navigation and sub-components.
+ * @param props.i18n - Locale dictionary for translated labels.
+ * @returns The sticky header section element.
+ */
 const HeaderComponent = async ({ domain, locale, i18n, ...props }: HeaderProps) => {
     const shop = await Shop.findByDomain(domain, { sensitiveData: true });
     const header = await HeaderApi({ shop, locale });

--- a/apps/storefront/src/components/header/info-bar.tsx
+++ b/apps/storefront/src/components/header/info-bar.tsx
@@ -20,6 +20,14 @@ export type InfoBarProps = {
     i18n: LocaleDictionary;
 } & Omit<HTMLProps<HTMLDivElement>, 'className'>;
 
+/**
+ * Async server component rendering a thin info bar with locale flag, email, and phone contact links.
+ *
+ * @param props.shop - Shop record used to fetch business contact info from the CMS.
+ * @param props.locale - Active locale forwarded to `LocaleFlag` and the API.
+ * @param props.i18n - Locale dictionary for translated labels.
+ * @returns The info-bar section, or `null` when no contact info is configured.
+ */
 export async function InfoBar({ shop, locale, i18n, ...props }: InfoBarProps) {
     const business = await InfoBarApi({ shop, locale });
     const email = business?.supportEmail?.trim() || null;

--- a/apps/storefront/src/components/informational/accepted-payment-methods.tsx
+++ b/apps/storefront/src/components/informational/accepted-payment-methods.tsx
@@ -16,6 +16,14 @@ export type AcceptedPaymentMethodsProps = {
     shop: OnlineShop;
 } & HTMLProps<HTMLDivElement>;
 
+/**
+ * Async server component displaying accepted payment method and digital wallet icons for the shop.
+ *
+ * @param props.shop - Shop record used to build the Shopify API client.
+ * @param props.locale - Active locale forwarded to the API client.
+ * @param props.className - Additional CSS class names.
+ * @returns A row of payment brand icons, or `null` when none are configured.
+ */
 export const AcceptedPaymentMethods = async ({ shop, locale, className, ...props }: AcceptedPaymentMethodsProps) => {
     const api = await ShopifyApiClient({ shop, locale });
     const paymentSettings = await ShopPaymentSettingsApi({ api });

--- a/apps/storefront/src/components/informational/alert.tsx
+++ b/apps/storefront/src/components/informational/alert.tsx
@@ -15,6 +15,15 @@ export type AlertProps = {
     children: React.ReactNode;
     icon?: false | React.ReactNode;
 } & HTMLProps<HTMLDivElement>;
+/**
+ * Themed alert box with an automatic severity icon and optional custom icon override.
+ *
+ * @param props.severity - Controls background color and the default icon.
+ * @param props.children - Alert body content.
+ * @param props.icon - Override icon element; pass `false` to suppress the default icon entirely.
+ * @param props.className - Additional CSS class names.
+ * @returns The styled alert element.
+ */
 export const Alert = ({ children, severity, icon, className, ...props }: AlertProps) => {
     let iconElement: React.ReactNode | null = null;
     if (typeof icon === 'undefined' || (typeof icon === 'boolean' && icon !== false)) {

--- a/apps/storefront/src/components/informational/avatar.tsx
+++ b/apps/storefront/src/components/informational/avatar.tsx
@@ -6,6 +6,14 @@ export type AvatarProps = {
     src?: string | null;
     name?: string | null;
 } & Omit<HTMLProps<HTMLDivElement>, 'name' | 'children' | 'src'>;
+/**
+ * Circular avatar showing a profile image when available, otherwise initials derived from `name`.
+ *
+ * @param props.src - URL of the profile image; initials are shown when absent.
+ * @param props.name - Display name used for the `title` attribute and initials fallback.
+ * @param props.className - Additional CSS class names.
+ * @returns The avatar element, or `null` when both `src` and `name` are absent.
+ */
 export async function Avatar({ src, name, title, className, ...props }: AvatarProps) {
     if (!src && !name) {
         return null;

--- a/apps/storefront/src/components/informational/breadcrumbs.skeleton.tsx
+++ b/apps/storefront/src/components/informational/breadcrumbs.skeleton.tsx
@@ -1,3 +1,8 @@
+/**
+ * Pulse-animated placeholder matching the breadcrumb strip's dimensions.
+ *
+ * @returns The skeleton breadcrumb element.
+ */
 export const BreadcrumbsSkeleton = () => {
     return (
         <section className="flex h-8 w-full max-w-full animate-pulse list-none flex-nowrap items-center justify-start gap-1 overflow-hidden whitespace-nowrap rounded-lg bg-gray-100 p-2 px-3 font-semibold" />

--- a/apps/storefront/src/components/informational/breadcrumbs.tsx
+++ b/apps/storefront/src/components/informational/breadcrumbs.tsx
@@ -16,6 +16,14 @@ type BreadcrumbsProps = {
     title?: string;
     className?: string;
 };
+/**
+ * Client component rendering a breadcrumb trail from the current pathname with injected JSON-LD markup.
+ *
+ * @param props.locale - Active locale used to build fully-qualified schema.org URLs.
+ * @param props.title - Overrides the label for the last breadcrumb entry.
+ * @param props.className - Additional CSS class names.
+ * @returns The breadcrumb strip with embedded JSON-LD, or `null` at the root path.
+ */
 const Breadcrumbs = ({ locale, title, className }: BreadcrumbsProps) => {
     const { shop } = useShop();
     const route = usePathname();

--- a/apps/storefront/src/components/informational/current-locale-flag.tsx
+++ b/apps/storefront/src/components/informational/current-locale-flag.tsx
@@ -9,6 +9,14 @@ export type CurrentLocaleFlagProps = {
     locale: Locale;
     alt?: string;
 } & Omit<ComponentProps<typeof Image>, 'src' | 'aria-label' | 'alt'>;
+/**
+ * Flag image for the currently active locale.
+ *
+ * @param props.locale - Active locale whose `country` code determines the flag SVG.
+ * @param props.alt - Alt text; defaults to the country code.
+ * @param props.className - Additional CSS class names.
+ * @returns The flag image element.
+ */
 export const CurrentLocaleFlag = ({
     locale,
     className,

--- a/apps/storefront/src/components/informational/locale-flag.tsx
+++ b/apps/storefront/src/components/informational/locale-flag.tsx
@@ -13,6 +13,16 @@ export type LocaleFlagProps = {
     nameClassName?: string;
     suffix?: ReactNode;
 } & Omit<ComponentProps<typeof Image>, 'src' | 'aria-label' | 'alt'>;
+/**
+ * Flag image with an optional country name label for a given locale.
+ *
+ * @param props.locale - Locale providing the country code used to look up the flag and name.
+ * @param props.withName - When `true`, renders the full country name next to the flag.
+ * @param props.nameClassName - CSS class names applied to the country name text.
+ * @param props.alt - Alt text; defaults to the country code.
+ * @param props.suffix - Node appended after the country name when `withName` is `true`.
+ * @returns The flag image, optionally followed by the country name and suffix.
+ */
 export const LocaleFlag = ({
     locale,
     withName = false,
@@ -63,6 +73,12 @@ export const LocaleFlag = ({
 export type LocaleCountryNameProps = {
     locale: Locale;
 };
+/**
+ * Returns the full country name for a locale's ISO country code.
+ *
+ * @param props.locale - Locale whose `country` code is looked up.
+ * @returns The full country name string, or `null` when the code is unrecognized.
+ */
 export function LocaleCountryName({ locale }: LocaleCountryNameProps) {
     let info: ReturnType<typeof countryLookup> | null = null;
     try {

--- a/apps/storefront/src/components/informational/vendors.tsx
+++ b/apps/storefront/src/components/informational/vendors.tsx
@@ -15,6 +15,14 @@ export type VendorsProps = {
 
     className?: string | undefined;
 };
+/**
+ * Async server component fetching all vendors from Shopify and rendering them as collection links.
+ *
+ * @param props.shop - Shop record used to build the Shopify API client.
+ * @param props.locale - Active locale forwarded to the API client.
+ * @param props.className - Additional CSS class names applied to each vendor link.
+ * @returns An array of vendor link elements, or `null` when there are no vendors.
+ */
 const Vendors = async ({ shop, locale, className, ...props }: VendorsProps) => {
     const api = await ShopifyApolloApiClient({ shop, locale });
 

--- a/apps/storefront/src/components/json-ld.tsx
+++ b/apps/storefront/src/components/json-ld.tsx
@@ -4,6 +4,12 @@ export type JsonLdProps = {
     data: Object;
 };
 
+/**
+ * Renders a JSON-LD `<script>` tag from a plain object.
+ *
+ * @param props.data - Structured data object serialized to JSON for injection into the page.
+ * @returns The inline script element, or `null` when `data` is falsy or fails serialization.
+ */
 export function JsonLd({ data }: JsonLdProps) {
     if (!data) {
         return null;

--- a/apps/storefront/src/components/layout/card.tsx
+++ b/apps/storefront/src/components/layout/card.tsx
@@ -17,6 +17,16 @@ export type CardProps<ComponentGeneric extends ElementType> = CardPropsBase<Comp
         ? Omit<ComponentPropsWithoutRef<ComponentGeneric>, keyof CardPropsBase<ComponentGeneric>>
         : ComponentPropsWithoutRef<ComponentGeneric>);
 
+/**
+ * Polymorphic layout card with `boxed` or `frameless` chrome styles.
+ *
+ * @param props.as - Element or component to render; defaults to `div`.
+ * @param props.chrome - Visual chrome variant: `'boxed'` applies border and background, `'frameless'` removes them.
+ * @param props.border - When `true`, uses a two-pixel border instead of the default background fill.
+ * @param props.className - Additional CSS class names.
+ * @param props.children - Card body content.
+ * @returns The rendered card element.
+ */
 export const Card = <ComponentGeneric extends ElementType = 'div'>({
     as,
     className,

--- a/apps/storefront/src/components/layout/modal.tsx
+++ b/apps/storefront/src/components/layout/modal.tsx
@@ -10,6 +10,15 @@ import { Label } from '@/components/typography/label';
 import type { LocaleDictionary } from '@/utils/locale';
 import { capitalize, getTranslations } from '@/utils/locale';
 
+/**
+ * Full-screen dialog modal that closes when the user navigates back.
+ *
+ * @param props.i18n - Locale dictionary for the close button label.
+ * @param props.title - Dialog title displayed in the header strip.
+ * @param props.description - Visually hidden description for assistive technology.
+ * @param props.children - Modal body content; returns `null` when absent.
+ * @returns The Radix `Dialog.Root` modal, or `null` when there are no children.
+ */
 export function Modal({
     i18n,
     title,

--- a/apps/storefront/src/components/layout/popover.tsx
+++ b/apps/storefront/src/components/layout/popover.tsx
@@ -15,6 +15,16 @@ export type PopoverProps = {
     children: ReactNode;
 };
 
+/**
+ * Centered dialog popover with a title, optional description, close button, and controllable open state.
+ *
+ * @param props.open - Whether the popover is currently visible.
+ * @param props.onOpenChange - Callback fired when the open state should change.
+ * @param props.title - Header label rendered inside a `Dialog.Title`.
+ * @param props.description - Optional visually hidden description for assistive technology.
+ * @param props.children - Popover body content.
+ * @returns The Radix `Dialog.Root` popover element.
+ */
 export function Popover({ open, onOpenChange, title, description, children }: PopoverProps) {
     return (
         <Dialog.Root open={open} onOpenChange={onOpenChange} modal={true}>

--- a/apps/storefront/src/components/layout/shop-layout.tsx
+++ b/apps/storefront/src/components/layout/shop-layout.tsx
@@ -17,6 +17,15 @@ export type ShopLayoutProps = {
     children: ReactNode;
 } & Omit<HTMLProps<HTMLDivElement>, 'data' | 'className'>;
 
+/**
+ * Async server component composing the full-page grid layout with info-bar, header, content, and footer.
+ *
+ * @param props.shop - Shop record forwarded to all child layout components.
+ * @param props.locale - Active locale forwarded to all child layout components.
+ * @param props.i18n - Locale dictionary forwarded to all child layout components.
+ * @param props.children - Main page content rendered in the content grid area.
+ * @returns The main grid container element.
+ */
 const ShopLayout = async ({ shop, locale, i18n, children }: ShopLayoutProps) => {
     return (
         <main className="grid min-h-screen grid-cols-[100%] grid-rows-[auto_auto_1fr_auto] [grid-template-areas:'info-bar''header''content''footer']">

--- a/apps/storefront/src/components/link.tsx
+++ b/apps/storefront/src/components/link.tsx
@@ -16,6 +16,13 @@ export type LinkProps = {
     href: Url | string;
 } & Omit<ComponentProps<typeof BaseLink>, 'locale'>;
 
+/**
+ * Returns `true` when `href` should be treated as an internal link.
+ *
+ * @param href - The URL string to check.
+ * @param shop - Optional shop record used to detect self-referencing external URLs.
+ * @returns `true` when the URL is relative or targets the current shop's domain.
+ */
 const isInternal = (href: string, shop?: OnlineShop): boolean => {
     if (href === '') {
         return true;
@@ -38,6 +45,14 @@ const isInternal = (href: string, shop?: OnlineShop): boolean => {
     return false;
 };
 
+/**
+ * Locale-aware wrapper around Next.js `Link` that injects the active locale into internal paths.
+ *
+ * @param props.locale - Explicit locale; falls back to shop context and `Locale.default`.
+ * @param props.href - Destination URL; supports strings and `Url` objects.
+ * @param props.prefetch - Forwarded to the underlying `BaseLink`; defaults to `false`.
+ * @returns The rendered `BaseLink` element, or `null` when `href` is not a string.
+ */
 export default function Link({ locale, href, prefetch, ...props }: LinkProps) {
     const shop = useShop();
 

--- a/apps/storefront/src/components/live-chat-provider.tsx
+++ b/apps/storefront/src/components/live-chat-provider.tsx
@@ -11,6 +11,13 @@ export type LiveChatProviderProps = {
     locale: Locale;
     children: ReactNode;
 };
+/**
+ * Client provider that mounts the Intercom live-chat widget in production when configured.
+ *
+ * @param props.shop - Shop record providing the Intercom app ID and primary accent color.
+ * @param props.children - Subtree rendered both with and without the live-chat widget.
+ * @returns The children, optionally wrapped with the Intercom provider and inline init script.
+ */
 export const LiveChatProvider = ({
     shop: {
         thirdParty: { intercom } = {},

--- a/apps/storefront/src/components/page-content.tsx
+++ b/apps/storefront/src/components/page-content.tsx
@@ -6,6 +6,15 @@ export type PageContentProps = {
     primary?: boolean;
     children?: ReactNode;
 } & HTMLProps<HTMLDivElement>;
+/**
+ * Polymorphic constrained-width content column used as the main page wrapper.
+ *
+ * @param props.as - Element or component to render; defaults to `div`.
+ * @param props.primary - When `true`, applies min-height, grid-area, and full-page padding.
+ * @param props.className - Additional CSS class names.
+ * @param props.children - Page content; returns `null` when absent.
+ * @returns The rendered content element, or `null` when there are no children.
+ */
 const PageContent = ({ as: Tag = 'div', primary, className, ...props }: PageContentProps) => {
     if (!props.children) {
         return null;

--- a/apps/storefront/src/components/product-card/__fixtures__/product-free-shipping.ts
+++ b/apps/storefront/src/components/product-card/__fixtures__/product-free-shipping.ts
@@ -1,6 +1,7 @@
 import type { Product } from '@/api/product';
 import { mockProduct } from '@/utils/test/fixtures';
 
+/** Returns a mock `Product` tagged with free shipping. */
 export const productFreeShipping = (): Product =>
     mockProduct({
         id: 'gid://shopify/Product/6',

--- a/apps/storefront/src/components/product-card/__fixtures__/product-gift-card.ts
+++ b/apps/storefront/src/components/product-card/__fixtures__/product-gift-card.ts
@@ -1,6 +1,7 @@
 import type { Product } from '@/api/product';
 import { mockProduct } from '@/utils/test/fixtures';
 
+/** Returns a mock `Product` configured as a gift card. */
 export const productGiftCard = (): Product =>
     mockProduct({
         id: 'gid://shopify/Product/7',

--- a/apps/storefront/src/components/product-card/__fixtures__/product-multi-image.ts
+++ b/apps/storefront/src/components/product-card/__fixtures__/product-multi-image.ts
@@ -1,6 +1,7 @@
 import type { Product } from '@/api/product';
 import { mockProduct } from '@/utils/test/fixtures';
 
+/** Returns a mock `Product` with two distinct product images. */
 export const productMultiImage = (): Product =>
     mockProduct({
         id: 'gid://shopify/Product/2',

--- a/apps/storefront/src/components/product-card/__fixtures__/product-multi-option.ts
+++ b/apps/storefront/src/components/product-card/__fixtures__/product-multi-option.ts
@@ -14,6 +14,14 @@ const COLORS = [
 
 const SIZES = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
 
+/**
+ * Creates a single variant node for the multi-option product fixture.
+ *
+ * @param color - Color option value.
+ * @param size - Size option value.
+ * @param index - Variant index used to generate a unique Shopify GID.
+ * @returns A minimal variant object with selected options and a fixed price.
+ */
 const makeVariant = (color: string, size: string, index: number) => ({
     id: `gid://shopify/ProductVariant/${index}`,
     title: `${color} / ${size}`,
@@ -32,6 +40,7 @@ const firstVariant = makeVariant(COLORS[0]!, SIZES[0]!, 0);
 // Pattern is the v1 trie: per Color index 0..7 → range of Size indices 0-5.
 const ENCODED = `v1_${COLORS.map((_, c) => `${c}:0-${SIZES.length - 1}`).join(',')}`;
 
+/** Returns a mock `Product` with eight colors and six sizes, producing a full cartesian variant matrix. */
 export const productMultiOption = (): Product =>
     mockProduct({
         id: 'gid://shopify/Product/3',

--- a/apps/storefront/src/components/product-card/__fixtures__/product-simple.ts
+++ b/apps/storefront/src/components/product-card/__fixtures__/product-simple.ts
@@ -1,6 +1,7 @@
 import type { Product } from '@/api/product';
 import { mockProduct } from '@/utils/test/fixtures';
 
+/** Returns a mock `Product` with a single variant, image, and no special attributes. */
 export const productSimple = (): Product =>
     mockProduct({
         id: 'gid://shopify/Product/1',

--- a/apps/storefront/src/components/product-card/__fixtures__/product-subscription.ts
+++ b/apps/storefront/src/components/product-card/__fixtures__/product-subscription.ts
@@ -1,6 +1,7 @@
 import type { Product } from '@/api/product';
 import { mockProduct } from '@/utils/test/fixtures';
 
+/** Returns a mock `Product` that requires a selling plan (subscription). */
 export const productSubscription = (): Product =>
     mockProduct({
         id: 'gid://shopify/Product/9',

--- a/apps/storefront/src/components/product-card/__fixtures__/product-vegan.ts
+++ b/apps/storefront/src/components/product-card/__fixtures__/product-vegan.ts
@@ -1,6 +1,7 @@
 import type { Product } from '@/api/product';
 import { mockProduct } from '@/utils/test/fixtures';
 
+/** Returns a mock `Product` tagged as vegan. */
 export const productVegan = (): Product =>
     mockProduct({
         id: 'gid://shopify/Product/8',

--- a/apps/storefront/src/components/product-card/__fixtures__/product-with-stock-urgency.ts
+++ b/apps/storefront/src/components/product-card/__fixtures__/product-with-stock-urgency.ts
@@ -1,6 +1,7 @@
 import type { Product } from '@/api/product';
 import { mockProduct } from '@/utils/test/fixtures';
 
+/** Returns a mock `Product` with a single low-stock variant to trigger urgency messaging. */
 export const productWithStockUrgency = (): Product =>
     mockProduct({
         id: 'gid://shopify/Product/4',

--- a/apps/storefront/src/components/product-card/__fixtures__/product-with-unavailable.ts
+++ b/apps/storefront/src/components/product-card/__fixtures__/product-with-unavailable.ts
@@ -1,6 +1,7 @@
 import type { Product } from '@/api/product';
 import { mockProduct } from '@/utils/test/fixtures';
 
+/** Returns a mock `Product` with three color variants where one variant is unavailable. */
 export const productWithUnavailable = (): Product =>
     mockProduct({
         id: 'gid://shopify/Product/5',

--- a/apps/storefront/src/components/product-card/cta/float-pill.tsx
+++ b/apps/storefront/src/components/product-card/cta/float-pill.tsx
@@ -4,6 +4,15 @@ import { Plus, X } from 'lucide-react';
 import { cn } from '@/utils/tailwind';
 import type { ProductCardCtaProps } from './types';
 
+/**
+ * Floating pill CTA button rendered in the product card image corner.
+ *
+ * @param props.isSingleBuyable - When `true`, tapping adds the item directly without opening the picker.
+ * @param props.isOpen - Whether the variant picker is currently open.
+ * @param props.onActivate - Callback to toggle the picker open state.
+ * @param props.onAdd - Callback invoked when the fast-path add-to-bag action is triggered.
+ * @returns The circular pill button element.
+ */
 const FloatPill = ({ isSingleBuyable, isOpen, onActivate, onAdd }: ProductCardCtaProps) => {
     const handleClick = () => {
         if (isOpen) {

--- a/apps/storefront/src/components/product-card/cta/registry.ts
+++ b/apps/storefront/src/components/product-card/cta/registry.ts
@@ -9,10 +9,22 @@ const registry = new Map<string, ProductCardCtaComponent>([
     ['inline-button', InlineButton],
 ]);
 
+/**
+ * Registers a custom CTA component under the given name, replacing any existing entry.
+ *
+ * @param name - Unique key used to look up the component via `getProductCardCta`.
+ * @param component - The CTA component to register.
+ */
 export function registerProductCardCta(name: string, component: ProductCardCtaComponent) {
     registry.set(name, component);
 }
 
+/**
+ * Retrieves the registered CTA component for the given name, falling back to `float-pill`.
+ *
+ * @param name - Registry key of the desired CTA component.
+ * @returns The matching component, or the `float-pill` fallback when no match is found.
+ */
 export function getProductCardCta(name: string): ProductCardCtaComponent {
     const found = registry.get(name);
     if (found) return found;

--- a/apps/storefront/src/components/product-card/picker/float.tsx
+++ b/apps/storefront/src/components/product-card/picker/float.tsx
@@ -7,6 +7,14 @@ import { toSelectionRecord } from '@/components/product-options/resolver';
 import { firstAvailableVariant } from '@/utils/first-available-variant';
 import type { ProductCardPickerProps } from './types';
 
+/**
+ * Floating popover picker that anchors to the CTA pill and shows a compact size selector.
+ *
+ * @param props.product - Product whose variants and options populate the picker.
+ * @param props.open - Whether the popover is currently open.
+ * @param props.onOpenChange - Callback invoked when the open state should change.
+ * @returns The Radix Popover element.
+ */
 const FloatPicker = ({ product, open, onOpenChange }: ProductCardPickerProps) => {
     const seed = firstAvailableVariant(product) ?? product.variants?.edges?.[0]?.node;
     const initialSelection = useMemo(() => (seed ? toSelectionRecord(seed) : {}), [seed]);

--- a/apps/storefront/src/components/product-card/picker/inline.tsx
+++ b/apps/storefront/src/components/product-card/picker/inline.tsx
@@ -6,6 +6,13 @@ import { toSelectionRecord } from '@/components/product-options/resolver';
 import { firstAvailableVariant } from '@/utils/first-available-variant';
 import type { ProductCardPickerProps } from './types';
 
+/**
+ * Inline expando picker that renders all product option groups directly inside the card layout.
+ *
+ * @param props.product - Product whose options and variants are displayed.
+ * @param props.open - When `false`, renders nothing.
+ * @returns The option group container, or `null` when closed.
+ */
 const InlinePicker = ({ product, open }: ProductCardPickerProps) => {
     const seed = firstAvailableVariant(product) ?? product.variants?.edges?.[0]?.node;
     const initialSelection = useMemo(() => toSelectionRecord(seed), [seed]);

--- a/apps/storefront/src/components/product-card/picker/registry.ts
+++ b/apps/storefront/src/components/product-card/picker/registry.ts
@@ -13,10 +13,22 @@ const registry = new Map<string, ProductCardPickerComponent>([
     ['inline', InlinePicker],
 ]);
 
+/**
+ * Registers a custom picker component under the given name, replacing any existing entry.
+ *
+ * @param name - Unique key used to look up the component via `getProductCardPicker`.
+ * @param component - The picker component to register.
+ */
 export function registerProductCardPicker(name: string, component: ProductCardPickerComponent) {
     registry.set(name, component);
 }
 
+/**
+ * Retrieves the registered picker component for the given name, falling back to `float`.
+ *
+ * @param name - Registry key of the desired picker component.
+ * @returns The matching component, or the `float` fallback when no match is found.
+ */
 export function getProductCardPicker(name: string): ProductCardPickerComponent {
     const found = registry.get(name);
     if (found) return found;

--- a/apps/storefront/src/components/product-card/picker/sheet.tsx
+++ b/apps/storefront/src/components/product-card/picker/sheet.tsx
@@ -9,6 +9,14 @@ import { toSelectionRecord } from '@/components/product-options/resolver';
 import { firstAvailableVariant } from '@/utils/first-available-variant';
 import type { ProductCardPickerProps } from './types';
 
+/**
+ * Sheet/modal picker that slides up from the bottom on mobile and centers on desktop.
+ *
+ * @param props.product - Product whose options and variants populate the dialog.
+ * @param props.open - Whether the dialog is currently open.
+ * @param props.onOpenChange - Callback invoked when the open state should change.
+ * @returns The Radix Dialog element.
+ */
 const SheetPicker = ({ product, open, onOpenChange }: ProductCardPickerProps) => {
     const seed = firstAvailableVariant(product) ?? product.variants?.edges?.[0]?.node;
     const initialSelection = useMemo(() => toSelectionRecord(seed), [seed]);

--- a/apps/storefront/src/components/product-card/primitives/product-card-badges.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-badges.tsx
@@ -10,6 +10,14 @@ export type ProductCardBadgesProps = {
     className?: string;
 };
 
+/**
+ * Thin server wrapper that renders `VariantBadges` with product-card prop naming.
+ *
+ * @param props.data - Product used to determine which badges to show.
+ * @param props.i18n - Locale dictionary for badge label translations.
+ * @param props.className - Additional CSS class names forwarded to `VariantBadges`.
+ * @returns The badge overlay element.
+ */
 const ProductCardBadges = ({ data, i18n, className }: ProductCardBadgesProps) => (
     <VariantBadges product={data} i18n={i18n} className={className} />
 );

--- a/apps/storefront/src/components/product-card/primitives/product-card-cta.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-cta.tsx
@@ -7,6 +7,12 @@ export type ProductCardCtaProps = {
     placement: string;
 };
 
+/**
+ * Client component that reads variant-selection context and renders the registered CTA for the given placement.
+ *
+ * @param props.placement - Registry key identifying which CTA component to render.
+ * @returns The resolved CTA element, or `null` when context is unavailable.
+ */
 const ProductCardCta = ({ placement }: ProductCardCtaProps) => {
     const sel = useVariantSelection();
     const picker = usePickerOpen();

--- a/apps/storefront/src/components/product-card/primitives/product-card-image.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-image.tsx
@@ -9,6 +9,16 @@ export type ProductCardImageProps = {
     className?: string;
 };
 
+/**
+ * Thin wrapper that forwards product-card image props to `VariantImage`.
+ *
+ * @param props.product - Product containing variant image data.
+ * @param props.seedVariant - Initial variant whose image is shown before selection.
+ * @param props.priority - When `true`, loads the primary image eagerly.
+ * @param props.aspect - Aspect ratio applied to the image container.
+ * @param props.className - Additional CSS class names.
+ * @returns The `VariantImage` element.
+ */
 const ProductCardImage = (props: ProductCardImageProps) => <VariantImage {...props} />;
 
 ProductCardImage.displayName = 'Nordcom.ProductCard.Image';

--- a/apps/storefront/src/components/product-card/primitives/product-card-options-provider.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-options-provider.tsx
@@ -26,6 +26,15 @@ export type ProductCardOptionsProviderProps = {
     children: ReactNode;
 };
 
+/**
+ * Provides variant-selection and picker-open state to the product card subtree via context.
+ *
+ * @param props.product - Product whose variants are selectable.
+ * @param props.seedVariantId - Initial selected variant ID before any user interaction.
+ * @param props.isSingleBuyable - Whether the product has only one purchasable variant.
+ * @param props.children - Card subtree that consumes the selection and picker contexts.
+ * @returns The nested context providers wrapping `children`.
+ */
 export function ProductCardOptionsProvider({
     product,
     seedVariantId,
@@ -51,5 +60,7 @@ export function ProductCardOptionsProvider({
     );
 }
 
+/** Returns the variant-selection context value, or `null` when used outside a `ProductCardOptionsProvider`. */
 export const useVariantSelection = () => useContext(VariantSelectionContext);
+/** Returns the picker-open context value, or `null` when used outside a `ProductCardOptionsProvider`. */
 export const usePickerOpen = () => useContext(PickerOpenContext);

--- a/apps/storefront/src/components/product-card/primitives/product-card-picker.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-picker.tsx
@@ -15,6 +15,15 @@ export type ProductCardPickerProps = {
     layout: 'vertical' | 'horizontal';
 };
 
+/**
+ * Resolves the concrete picker variant from the requested presentation mode and current context.
+ *
+ * @param presentation - Requested presentation; `'auto'` defers to layout and device heuristics.
+ * @param layout - Card layout direction used to select a sensible default.
+ * @param ctaPlacement - CTA registry key; `'inline-button'` selects the inline picker when in auto mode.
+ * @param isMobile - Whether the viewport is narrower than the md breakpoint.
+ * @returns The resolved non-auto presentation variant.
+ */
 const resolvePresentation = (
     presentation: Presentation,
     layout: 'vertical' | 'horizontal',
@@ -28,6 +37,16 @@ const resolvePresentation = (
     return 'float';
 };
 
+/**
+ * Client component that resolves and renders the appropriate variant picker for the product card.
+ *
+ * @param props.locale - Active locale forwarded to the resolved picker.
+ * @param props.i18n - Locale dictionary forwarded to the resolved picker.
+ * @param props.presentation - Preferred picker presentation mode; `'auto'` adapts to layout and device.
+ * @param props.ctaPlacement - CTA registry key used in auto-mode resolution.
+ * @param props.layout - Card layout direction used in auto-mode resolution.
+ * @returns The resolved picker element, or `null` when context is unavailable.
+ */
 const ProductCardPicker = ({ locale, i18n, presentation, ctaPlacement, layout }: ProductCardPickerProps) => {
     const sel = useVariantSelection();
     const picker = usePickerOpen();

--- a/apps/storefront/src/components/product-card/primitives/product-card-price.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-price.tsx
@@ -9,6 +9,14 @@ export type ProductCardPriceProps = {
     className?: string;
 };
 
+/**
+ * Displays the formatted current price and, when on sale, a struck-through compare-at price.
+ *
+ * @param props.seedVariant - Variant providing the current price and optional compare-at price.
+ * @param props.locale - Locale used for `Intl.NumberFormat` currency formatting.
+ * @param props.className - Additional CSS class names.
+ * @returns The price display element.
+ */
 const ProductCardPrice = ({ seedVariant, locale, className }: ProductCardPriceProps) => {
     const current = seedVariant.price;
     const compare = seedVariant.compareAtPrice;

--- a/apps/storefront/src/components/product-card/primitives/product-card-root.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-root.tsx
@@ -15,6 +15,17 @@ export type ProductCardRootProps = {
     children: ReactNode;
 };
 
+/**
+ * Root `<article>` wrapper for the product card, applying layout, chrome, and availability data attributes.
+ *
+ * @param props.data - Product record used to derive out-of-stock state.
+ * @param props.layout - Card orientation; controls flex direction and minimum height.
+ * @param props.chrome - Visual frame style; `'boxed'` adds a shadow border.
+ * @param props.onSale - When `true`, sets a `data-on-sale` attribute for sale-specific styling.
+ * @param props.className - Additional CSS class names.
+ * @param props.children - Card content slots.
+ * @returns The `Card` article element.
+ */
 const ProductCardRoot = ({ data, layout, chrome, onSale, className, children }: ProductCardRootProps) => {
     const isOos = data.availableForSale === false;
 

--- a/apps/storefront/src/components/product-card/primitives/product-card-sale-badge.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-sale-badge.tsx
@@ -27,6 +27,16 @@ export type ProductCardSaleBadgeProps = {
     collisionShift?: boolean;
 };
 
+/**
+ * Absolute-positioned badge showing the discount percentage; hidden when the discount is below 11%.
+ *
+ * @param props.discountPercent - Integer discount percentage; values below 11 render nothing.
+ * @param props.style - Visual color scheme for the badge.
+ * @param props.position - Corner anchor position within the card image area.
+ * @param props.className - Additional CSS class names.
+ * @param props.collisionShift - When `true`, offsets the badge to avoid overlapping the corner CTA.
+ * @returns The sale badge element, or `null` when the discount is too small to display.
+ */
 const ProductCardSaleBadge = ({
     discountPercent,
     style,

--- a/apps/storefront/src/components/product-card/primitives/product-card-stock-urgency.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-stock-urgency.tsx
@@ -9,6 +9,15 @@ export type ProductCardStockUrgencyProps = {
     className?: string;
 };
 
+/**
+ * Thin wrapper that forwards product-card stock-urgency props to `VariantStockUrgency`.
+ *
+ * @param props.seedVariant - Variant providing the quantity-available count.
+ * @param props.i18n - Locale dictionary for urgency label translations.
+ * @param props.threshold - Maximum quantity that triggers the urgency message.
+ * @param props.className - Additional CSS class names.
+ * @returns The `VariantStockUrgency` element.
+ */
 const ProductCardStockUrgency = (props: ProductCardStockUrgencyProps) => <VariantStockUrgency {...props} />;
 
 ProductCardStockUrgency.displayName = 'Nordcom.ProductCard.StockUrgency';

--- a/apps/storefront/src/components/product-card/primitives/product-card-title.tsx
+++ b/apps/storefront/src/components/product-card/primitives/product-card-title.tsx
@@ -10,6 +10,14 @@ export type ProductCardTitleProps = {
     className?: string;
 };
 
+/**
+ * Server component rendering the product title and, when the shop setting permits, the vendor name.
+ *
+ * @param props.shop - Shop configuration that controls whether the vendor line is shown.
+ * @param props.data - Product providing the title and vendor.
+ * @param props.className - CSS class names forwarded to `VariantTitle`.
+ * @returns The `VariantTitle` element.
+ */
 const ProductCardTitle = ({ shop, data, className }: ProductCardTitleProps) => {
     const showVendor = shop.showProductVendor === true;
     return <VariantTitle product={data} showVendor={showVendor} className={className ?? 'product-card-title'} />;

--- a/apps/storefront/src/components/product-card/product-card.tsx
+++ b/apps/storefront/src/components/product-card/product-card.tsx
@@ -136,6 +136,13 @@ export default async function ProductCard({
 
 ProductCard.displayName = 'Nordcom.ProductCard';
 
+/**
+ * Lightweight skeleton placeholder matching the card's minimum dimensions while data loads.
+ *
+ * @param props.layout - Card orientation used to set matching CSS data attributes.
+ * @param props.chrome - Visual frame style set as a data attribute for styling hooks.
+ * @returns An empty positioned div with skeleton data attributes.
+ */
 ProductCard.skeleton = ({
     layout = 'vertical' as ProductCardLayout,
     chrome = 'boxed' as ProductCardChrome,

--- a/apps/storefront/src/components/product-display/primitives/variant-badges.tsx
+++ b/apps/storefront/src/components/product-display/primitives/variant-badges.tsx
@@ -16,6 +16,14 @@ export type VariantBadgesProps = {
     className?: string;
 };
 
+/**
+ * Server component rendering overlay badges for attributes such as vegan, sale, subscription, gift card, and free shipping.
+ *
+ * @param props.product - Product data used to determine which badges to display.
+ * @param props.i18n - Locale dictionary for translated badge labels.
+ * @param props.className - Additional CSS class names.
+ * @returns The badge overlay element, or `null` when no applicable variant exists.
+ */
 const VariantBadges = ({ product, i18n, className }: VariantBadgesProps) => {
     const selectedVariant = firstAvailableVariant(product);
     const { t } = getTranslations('product', i18n);

--- a/apps/storefront/src/components/product-display/primitives/variant-image-client.tsx
+++ b/apps/storefront/src/components/product-display/primitives/variant-image-client.tsx
@@ -24,11 +24,29 @@ export type VariantImageClientProps = {
     className?: string;
 };
 
+/**
+ * Returns the Tailwind aspect-ratio class for a given card image aspect.
+ *
+ * @param aspect - The desired aspect ratio variant.
+ * @returns The corresponding Tailwind CSS class name.
+ */
 const aspectClass = (aspect: VariantImageClientProps['aspect']) => {
     if (aspect === 'horizontal' || aspect === 'square') return 'aspect-(--aspect-product-card-horizontal)';
     return 'aspect-(--aspect-product-card-vertical)';
 };
 
+/**
+ * Client component rendering the product card image, swapping to the selected or hovered variant image.
+ *
+ * @param props.initialImage - Server-rendered seed image shown before hydration.
+ * @param props.swapImage - Secondary image revealed on hover.
+ * @param props.aspect - Aspect ratio class applied to the image container.
+ * @param props.href - Link destination wrapping the image.
+ * @param props.title - Accessible title for the link and fallback alt text.
+ * @param props.priority - When `true`, loads the primary image eagerly.
+ * @param props.className - Additional CSS class names applied to the link wrapper.
+ * @returns The image link element, or a placeholder icon when no image is available.
+ */
 const VariantImageClient = ({
     initialImage,
     swapImage,

--- a/apps/storefront/src/components/product-display/primitives/variant-image.tsx
+++ b/apps/storefront/src/components/product-display/primitives/variant-image.tsx
@@ -10,6 +10,13 @@ export type VariantImageProps = {
     className?: string;
 };
 
+/**
+ * Resolves the primary image for a product card from the variant image, featured image, or first gallery image.
+ *
+ * @param product - Product providing featured and gallery images as fallbacks.
+ * @param seedVariant - Variant whose image takes precedence when available.
+ * @returns The resolved seed image, or `null` when no image source is found.
+ */
 const pickSeedImage = (product: Product, seedVariant: ProductVariant): SeedImage | null => {
     const v = seedVariant.image;
     if (v?.url) {
@@ -41,6 +48,13 @@ const pickSeedImage = (product: Product, seedVariant: ProductVariant): SeedImage
     return null;
 };
 
+/**
+ * Returns the second product gallery image to use as a hover swap, or `null` when unavailable.
+ *
+ * @param product - Product providing the gallery image list.
+ * @param primary - Already-resolved primary image used to skip duplicates.
+ * @returns The swap image, or `null` when there is no distinct second gallery image.
+ */
 const pickSwapImage = (product: Product, primary: SeedImage | null): SeedImage | null => {
     const second = product.images?.edges?.[1]?.node;
     if (!second?.url || !primary) return null;
@@ -53,6 +67,16 @@ const pickSwapImage = (product: Product, primary: SeedImage | null): SeedImage |
     };
 };
 
+/**
+ * Server-side shell that resolves the primary and swap images then passes them to `VariantImageClient`.
+ *
+ * @param props.product - Product providing image gallery and vendor/title for link text.
+ * @param props.seedVariant - Initial variant whose image is used as the primary image source.
+ * @param props.priority - When `true`, loads the primary image eagerly.
+ * @param props.aspect - Aspect ratio applied to the image container.
+ * @param props.className - Additional CSS class names forwarded to the client component.
+ * @returns The `VariantImageClient` element.
+ */
 const VariantImage = ({
     product,
     seedVariant,

--- a/apps/storefront/src/components/product-display/primitives/variant-price-client.tsx
+++ b/apps/storefront/src/components/product-display/primitives/variant-price-client.tsx
@@ -12,6 +12,16 @@ export type VariantPriceClientProps = {
     className?: string;
 };
 
+/**
+ * Client component displaying the price, compare-at price, and sale percentage for the selected variant.
+ *
+ * @param props.initialPrice - Pre-formatted price string rendered before hydration.
+ * @param props.initialCompare - Pre-formatted compare-at price, or `null` when not on sale.
+ * @param props.initialPct - Pre-computed sale percentage, or `null` when not on sale.
+ * @param props.locale - Locale code for number and currency formatting.
+ * @param props.className - Additional CSS class names.
+ * @returns The price display element.
+ */
 const VariantPriceClient = ({
     initialPrice,
     initialCompare,

--- a/apps/storefront/src/components/product-display/primitives/variant-price.tsx
+++ b/apps/storefront/src/components/product-display/primitives/variant-price.tsx
@@ -9,6 +9,14 @@ export type VariantPriceProps = {
     className?: string;
 };
 
+/**
+ * Server-side shell that pre-formats price data and passes it to `VariantPriceClient`.
+ *
+ * @param props.seedVariant - Product variant providing price and compare-at price.
+ * @param props.locale - Locale code forwarded to the client for formatting.
+ * @param props.className - Additional CSS class names.
+ * @returns The `VariantPriceClient` element.
+ */
 const VariantPrice = ({ seedVariant, locale, className }: VariantPriceProps) => {
     const initialPrice = formatPrice(seedVariant.price, locale);
     const initialCompare = seedVariant.compareAtPrice ? formatPrice(seedVariant.compareAtPrice, locale) : null;

--- a/apps/storefront/src/components/product-display/primitives/variant-stock-urgency-client.tsx
+++ b/apps/storefront/src/components/product-display/primitives/variant-stock-urgency-client.tsx
@@ -11,12 +11,29 @@ export type VariantStockUrgencyClientProps = {
     className?: string;
 };
 
+/**
+ * Builds a translated stock-urgency message when the quantity falls within the threshold.
+ *
+ * @param qty - Current available quantity for the variant.
+ * @param threshold - Maximum quantity that triggers the urgency message.
+ * @param i18n - Locale dictionary for the translated message string.
+ * @returns The formatted urgency string, or `null` when no urgency should be shown.
+ */
 function buildMessage(qty: number | null | undefined, threshold: number, i18n: LocaleDictionary): string | null {
     if (typeof qty !== 'number' || qty <= 0 || qty > threshold) return null;
     const { t } = getTranslations('product', i18n);
     return t('only-n-left', qty);
 }
 
+/**
+ * Client component displaying a low-stock urgency message, updating when the selected variant changes.
+ *
+ * @param props.initialMessage - Pre-computed message rendered before hydration, or `null` when not in stock urgency.
+ * @param props.threshold - Quantity ceiling used to recompute the message for the selected variant.
+ * @param props.i18n - Locale dictionary for the urgency message translation.
+ * @param props.className - Additional CSS class names applied to the urgency span.
+ * @returns The urgency message element, or `null` when no message applies.
+ */
 const VariantStockUrgencyClient = ({ initialMessage, threshold, i18n, className }: VariantStockUrgencyClientProps) => {
     const ctx = useMaybeProductOptions();
     const selectedVariant = ctx?.selectedVariant;

--- a/apps/storefront/src/components/product-display/primitives/variant-stock-urgency.tsx
+++ b/apps/storefront/src/components/product-display/primitives/variant-stock-urgency.tsx
@@ -10,6 +10,15 @@ export type VariantStockUrgencyProps = {
     className?: string;
 };
 
+/**
+ * Server-side shell that pre-computes the initial urgency message and passes it to `VariantStockUrgencyClient`.
+ *
+ * @param props.seedVariant - Variant providing the initial available quantity.
+ * @param props.threshold - Maximum quantity that triggers the urgency message; defaults to 5.
+ * @param props.i18n - Locale dictionary for the urgency message translation.
+ * @param props.className - Additional CSS class names.
+ * @returns The `VariantStockUrgencyClient` element.
+ */
 const VariantStockUrgency = ({ seedVariant, threshold = 5, i18n, className }: VariantStockUrgencyProps) => {
     const qty = seedVariant.quantityAvailable;
     let initialMessage: string | null = null;

--- a/apps/storefront/src/components/product-options-selector/product-options-selector.tsx
+++ b/apps/storefront/src/components/product-options-selector/product-options-selector.tsx
@@ -46,6 +46,18 @@ export type ProductOptionsSelectorProps = {
 type SelectorOption = ProductOptionsSelectorProps['options'][number];
 type SelectorOptionValue = SelectorOption['optionValues'][number];
 
+/**
+ * Renders the full set of product option groups, delegating value rendering to pluggable renderer components.
+ *
+ * @param props.options - Array of product option groups with their available values.
+ * @param props.selectedOptions - Map of option name to currently selected value.
+ * @param props.onChange - Callback invoked with the updated selection map on any value change.
+ * @param props.renderers - Optional per-option-name renderer overrides; falls back to `defaultRenderers.default`.
+ * @param props.productHandle - Product handle used to build variant deep-link hrefs when provided.
+ * @param props.density - Visual density mode forwarded to each value renderer.
+ * @param props.maxValuesPerOption - Optional cap on displayed values per option group.
+ * @returns The option group container, or `null` when no real options exist.
+ */
 export const ProductOptionsSelector = ({
     options,
     selectedOptions,

--- a/apps/storefront/src/components/product-options-selector/renderers/size-chip-renderer.tsx
+++ b/apps/storefront/src/components/product-options-selector/renderers/size-chip-renderer.tsx
@@ -6,6 +6,19 @@ import { useShop } from '@/components/shop/provider';
 import { formatWeight, localizeWeight } from '@/utils/locale';
 import { chipClassName } from './chip-class';
 
+/**
+ * Chip renderer for size-type options, optionally showing a weight sub-label in spacious density.
+ *
+ * @param props.name - Option group name used for accessible aria labels.
+ * @param props.value - Option value label displayed in the chip.
+ * @param props.selected - Whether this chip is the currently selected value.
+ * @param props.available - When `false`, the chip is visually disabled and clicks are suppressed.
+ * @param props.onSelect - Callback invoked when the chip is selected.
+ * @param props.href - Optional deep-link href; renders an anchor instead of a button when provided.
+ * @param props.density - Visual density; `'spacious'` shows the weight sub-label.
+ * @param props.variant - Variant providing weight metadata for the sub-label.
+ * @returns An anchor or button chip element.
+ */
 export const SizeChipRenderer = ({
     name,
     value,

--- a/apps/storefront/src/components/product-options-selector/renderers/text-chip-renderer.tsx
+++ b/apps/storefront/src/components/product-options-selector/renderers/text-chip-renderer.tsx
@@ -4,6 +4,19 @@ import type { MouseEvent } from 'react';
 import type { ProductOptionValueRendererProps } from '@/components/product-options-selector/renderers/types';
 import { chipClassName } from './chip-class';
 
+/**
+ * Default chip renderer for text-type options, with optional swatch color or image preview.
+ *
+ * @param props.name - Option group name used for accessible aria labels.
+ * @param props.value - Option value label displayed in the chip.
+ * @param props.selected - Whether this chip is the currently selected value.
+ * @param props.available - When `false`, the chip is disabled and click navigation is suppressed.
+ * @param props.onSelect - Callback invoked when the chip is selected.
+ * @param props.swatch - Optional color or image swatch shown as a leading circle.
+ * @param props.href - Optional deep-link href; renders an anchor instead of a button when provided.
+ * @param props.density - Visual density forwarded to `chipClassName`.
+ * @returns An anchor or button chip element.
+ */
 export const TextChipRenderer = ({
     name,
     value,

--- a/apps/storefront/src/components/product-options/context.ts
+++ b/apps/storefront/src/components/product-options/context.ts
@@ -4,12 +4,23 @@ import type { ProductOptionsContextValue } from './types';
 
 export const ProductOptionsContext = createContext<ProductOptionsContextValue | null>(null);
 
+/**
+ * Returns the product-options context value, throwing when called outside a `ProductOptions.Root`.
+ *
+ * @returns The current `ProductOptionsContextValue`.
+ * @throws When used outside a `ProductOptions.Root` provider.
+ */
 export function useProductOptions(): ProductOptionsContextValue {
     const ctx = useContext(ProductOptionsContext);
     if (!ctx) throw new Error('useProductOptions must be used inside <ProductOptions.Root>');
     return ctx;
 }
 
+/**
+ * Returns the product-options context value, or `null` when called outside a `ProductOptions.Root`.
+ *
+ * @returns The current `ProductOptionsContextValue`, or `null` when no provider is present.
+ */
 export function useMaybeProductOptions(): ProductOptionsContextValue | null {
     return useContext(ProductOptionsContext);
 }

--- a/apps/storefront/src/components/product-options/primitives/chip.tsx
+++ b/apps/storefront/src/components/product-options/primitives/chip.tsx
@@ -2,6 +2,13 @@
 
 import type { OptionValueRendererProps } from '../types';
 
+/**
+ * Text chip button for a single option value, reflecting selected and available states.
+ *
+ * @param props.value - Option value data including name, selected, and available flags.
+ * @param props.onSelect - Callback invoked when the chip is clicked.
+ * @returns The chip button element.
+ */
 const Chip = ({ value, onSelect }: OptionValueRendererProps) => (
     <button
         type="button"

--- a/apps/storefront/src/components/product-options/primitives/group.tsx
+++ b/apps/storefront/src/components/product-options/primitives/group.tsx
@@ -8,6 +8,13 @@ export type GroupProps = {
     density?: 'compact' | 'spacious';
 };
 
+/**
+ * Renders all values for a named option group from the product-options context.
+ *
+ * @param props.name - Option group name used to look up the group from the resolved options.
+ * @param props.density - Visual density forwarded to each `Value` renderer.
+ * @returns The swatch row element, or `null` when the named group is not found.
+ */
 const Group = ({ name, density = 'compact' }: GroupProps) => {
     const { resolved } = useProductOptions();
     const group = resolved.find((g) => g.name === name);

--- a/apps/storefront/src/components/product-options/primitives/more.tsx
+++ b/apps/storefront/src/components/product-options/primitives/more.tsx
@@ -8,6 +8,14 @@ export type MoreProps = {
     className?: string;
 };
 
+/**
+ * Overflow button showing a count of hidden option values beyond the first four.
+ *
+ * @param props.groupName - Option group name used to count overflow values from context.
+ * @param props.onClick - Callback invoked when the overflow button is clicked.
+ * @param props.className - CSS class names applied to the button; uses a default pill style when omitted.
+ * @returns The overflow count button, or `null` when the group is not found or has no overflow.
+ */
 const More = ({ groupName, onClick, className }: MoreProps) => {
     const { resolved } = useProductOptions();
     const group = resolved.find((g) => g.name === groupName);

--- a/apps/storefront/src/components/product-options/primitives/overlay.tsx
+++ b/apps/storefront/src/components/product-options/primitives/overlay.tsx
@@ -11,6 +11,12 @@ export type OverlayProps = {
     groupName: string;
 };
 
+/**
+ * Full-value overlay for an option group, rendering as a popover on desktop and a bottom sheet on mobile.
+ *
+ * @param props.groupName - Option group name whose values are displayed in the overlay.
+ * @returns A Radix Popover or Dialog element depending on viewport, or `null` when the group is not found.
+ */
 const Overlay = ({ groupName }: OverlayProps) => {
     const isDesktop = useIsDesktop();
     const [open, setOpen] = useState(false);

--- a/apps/storefront/src/components/product-options/primitives/swatch.tsx
+++ b/apps/storefront/src/components/product-options/primitives/swatch.tsx
@@ -2,6 +2,13 @@
 
 import type { OptionValueRendererProps } from '../types';
 
+/**
+ * Color or image swatch button for a single option value, with a struck-through diagonal line when unavailable.
+ *
+ * @param props.value - Option value data including swatch, selected, and available fields.
+ * @param props.onSelect - Callback invoked when the swatch is clicked.
+ * @returns The swatch button element.
+ */
 const Swatch = ({ value, onSelect }: OptionValueRendererProps) => {
     const hasImage = !!value.swatch?.image?.url && !value.swatch?.color;
     return (

--- a/apps/storefront/src/components/product-options/primitives/value.tsx
+++ b/apps/storefront/src/components/product-options/primitives/value.tsx
@@ -11,6 +11,14 @@ export type ValueProps = {
     density?: 'compact' | 'spacious';
 };
 
+/**
+ * Dispatches to the appropriate renderer for a single option value based on the group name and value type.
+ *
+ * @param props.group - Resolved option group providing name and renderer lookup key.
+ * @param props.value - Resolved option value passed to the selected renderer.
+ * @param props.density - Visual density forwarded to the renderer.
+ * @returns The renderer element for this option value.
+ */
 const Value = ({ group, value, density = 'compact' }: ValueProps) => {
     const { selection, selectVariant, renderers } = useProductOptions();
     const onSelect = useCallback(() => {

--- a/apps/storefront/src/components/product-options/product-options.tsx
+++ b/apps/storefront/src/components/product-options/product-options.tsx
@@ -16,6 +16,12 @@ export type ProductOptionsRootProps = {
     children?: ReactNode;
 };
 
+/**
+ * Lowercases all keys of a renderer map so lookups are case-insensitive.
+ *
+ * @param input - Optional renderer map with arbitrary-case keys.
+ * @returns A new map with all keys lowercased, or an empty object when `input` is undefined.
+ */
 function normalizeRenderers(
     input: Record<string, OptionValueRenderer> | undefined,
 ): Record<string, OptionValueRenderer> {
@@ -23,6 +29,17 @@ function normalizeRenderers(
     return Object.fromEntries(Object.entries(input).map(([k, v]) => [k.toLowerCase(), v]));
 }
 
+/**
+ * Mounts the `ProductOptionsContext` provider with internally managed or controlled selection state.
+ *
+ * @param props.product - Product whose options and variants are resolved.
+ * @param props.initialSelection - Uncontrolled initial selection map.
+ * @param props.selection - Controlled selection map; when provided, the component is fully controlled.
+ * @param props.onChange - Callback invoked on every selection change.
+ * @param props.renderers - Custom per-option-name renderer overrides.
+ * @param props.children - Context consumers.
+ * @returns The context provider wrapping `children`.
+ */
 const InnerRoot = ({
     product,
     initialSelection,
@@ -69,6 +86,13 @@ const InnerRoot = ({
     return <ProductOptionsContext.Provider value={value}>{children}</ProductOptionsContext.Provider>;
 };
 
+/**
+ * Public root component for product options; passes through to the nearest parent provider when nested.
+ *
+ * @param props.product - Product whose options are managed by this root.
+ * @param props.children - Option group and value primitives that consume the context.
+ * @returns The `InnerRoot` provider, or a transparent fragment when a parent provider already exists.
+ */
 const Root = (props: ProductOptionsRootProps) => {
     const parent = useMaybeProductOptions();
     if (parent) {

--- a/apps/storefront/src/components/product-options/renderers/index.ts
+++ b/apps/storefront/src/components/product-options/renderers/index.ts
@@ -5,6 +5,13 @@ import type { OptionValueRenderer, ResolvedOption, ResolvedOptionValue } from '.
 const SIZE_NAME_RE = /^(size|größe|storlek|talla|taille)$/i;
 const SIZE_VALUE_RE = /^(XS|S|M|L|XL|XXL|\d{2,3}|\d+(\.\d)?)$/;
 
+/**
+ * Returns the built-in renderer best suited for the given option group and value.
+ *
+ * @param group - Resolved option group used to check the group name against size patterns.
+ * @param value - Resolved option value used to check for a swatch color or image.
+ * @returns `Swatch` when the value has a swatch, otherwise `Chip`.
+ */
 export function pickBuiltin(group: ResolvedOption, value: ResolvedOptionValue): OptionValueRenderer {
     if (value.swatch?.color) return Swatch;
     if (value.swatch?.image?.url) return Swatch;

--- a/apps/storefront/src/components/product-options/resolver.ts
+++ b/apps/storefront/src/components/product-options/resolver.ts
@@ -27,6 +27,12 @@ type RawOption = {
     values?: string[];
 };
 
+/**
+ * Normalizes a raw Shopify swatch shape into the internal `ResolvedSwatch` format.
+ *
+ * @param raw - Raw swatch data from Shopify with optional color and nested image references.
+ * @returns A normalized swatch object, or `undefined` when neither a color nor an image URL is present.
+ */
 function normalizeSwatch(raw: RawSwatch | undefined): ResolvedSwatch | undefined {
     if (!raw) return undefined;
     const previewUrl = raw.image?.previewImage?.url ?? raw.image?.image?.url ?? raw.image?.url;
@@ -43,6 +49,12 @@ function normalizeSwatch(raw: RawSwatch | undefined): ResolvedSwatch | undefined
     return { color, image };
 }
 
+/**
+ * Yields each option value from either the `optionValues` or legacy `values` array.
+ *
+ * @param option - Raw product option containing either `optionValues` (new) or `values` (legacy) entries.
+ * @returns A generator of `{ name, swatch? }` entries.
+ */
 function* iterValues(option: RawOption): Generator<{ name: string; swatch?: RawSwatch }> {
     if (Array.isArray(option.optionValues) && option.optionValues.length > 0) {
         for (const ov of option.optionValues) yield { name: ov.name, swatch: ov.swatch };
@@ -53,6 +65,13 @@ function* iterValues(option: RawOption): Generator<{ name: string; swatch?: RawS
     }
 }
 
+/**
+ * Returns the first product variant whose selected options exactly match the given selection map.
+ *
+ * @param product - Product providing the variant list.
+ * @param selection - Map of option name to value representing the current selection.
+ * @returns The matching variant, or `undefined` when no variant matches the full selection.
+ */
 export function findVariant(product: Product, selection: Record<string, string>): ProductVariant | undefined {
     const edges = product.variants?.edges ?? [];
     return edges
@@ -64,6 +83,15 @@ export function findVariant(product: Product, selection: Record<string, string>)
         );
 }
 
+/**
+ * Determines whether a given option value is available for sale given the current selection.
+ *
+ * @param product - Product providing the full variant list.
+ * @param optionName - Name of the option being evaluated.
+ * @param valueName - Specific option value to check for availability.
+ * @param selection - Current selection map used to filter compatible variants.
+ * @returns `true` when at least one variant with this option value and matching selection is available for sale.
+ */
 function deriveAvailability(
     product: Product,
     optionName: string,
@@ -81,6 +109,13 @@ function deriveAvailability(
     });
 }
 
+/**
+ * Resolves all meaningful product options into a display-ready structure with selected and availability state.
+ *
+ * @param product - Product whose options and variants are resolved.
+ * @param selection - Current selection map used to compute per-value selected and available flags.
+ * @returns Array of resolved option groups, excluding the default `'title'` option.
+ */
 export function resolveOptions(product: Product, selection: Record<string, string>): ResolvedOption[] {
     const options = (product.options ?? []) as unknown as RawOption[];
     return options
@@ -97,6 +132,12 @@ export function resolveOptions(product: Product, selection: Record<string, strin
         }));
 }
 
+/**
+ * Converts a variant's selected options array into a flat option-name-to-value map.
+ *
+ * @param variant - Variant whose `selectedOptions` are flattened into a record.
+ * @returns A record mapping option names to their selected values, or an empty object when `variant` is undefined.
+ */
 export function toSelectionRecord(variant: ProductVariant | undefined): Record<string, string> {
     if (!variant) return {};
     return Object.fromEntries((variant.selectedOptions ?? []).map((so) => [so.name, so.value]));

--- a/apps/storefront/src/components/products/add-to-cart.tsx
+++ b/apps/storefront/src/components/products/add-to-cart.tsx
@@ -26,6 +26,17 @@ export type AddToCartProps = {
     };
 } & Omit<HTMLProps<HTMLButtonElement>, 'data'>;
 
+/**
+ * Add-to-cart button that fires a cart line mutation and emits a tracking event on success.
+ *
+ * @param props.i18n - Locale dictionary for button labels and toast messages.
+ * @param props.redirect - When `true`, navigates to `/cart/` after a successful add.
+ * @param props.disabled - Overrides the ready-state check to force a disabled state.
+ * @param props.quantity - Number of units to add; values below 1 disable the button.
+ * @param props.data - Object containing the product and selected variant to add.
+ * @param props.children - Optional label override; defaults to the i18n add-to-cart string.
+ * @returns The `Button` element wired to the cart add action.
+ */
 export function AddToCart({
     i18n,
     redirect = false,

--- a/apps/storefront/src/components/products/collection-block.tsx
+++ b/apps/storefront/src/components/products/collection-block.tsx
@@ -50,6 +50,24 @@ export type CollectionBlockProps<ComponentGeneric extends ElementType> = Collect
         ? Omit<ComponentPropsWithoutRef<ComponentGeneric>, keyof CollectionBlockBase<ComponentGeneric>>
         : ComponentPropsWithoutRef<ComponentGeneric>);
 
+/**
+ * Async server component that fetches a collection and renders its products as a responsive card grid or horizontal rail.
+ *
+ * @param props.as - Wrapper element type; defaults to `'div'`.
+ * @param props.shop - Shop record forwarded to the Shopify API client.
+ * @param props.locale - Locale forwarded to the API client and each product card.
+ * @param props.handle - Collection handle to fetch; when omitted only `children` are rendered.
+ * @param props.limit - Maximum number of products to fetch.
+ * @param props.filters - Additional collection query filters.
+ * @param props.isHorizontal - When `true`, lays out as a horizontally scrollable rail.
+ * @param props.showViewAll - When `true`, appends a view-all tile at the end of the grid.
+ * @param props.priority - Passed to the first two product cards for eager image loading.
+ * @param props.bare - When `true`, renders cards without a wrapper element.
+ * @param props.card - Custom card component; defaults to `CollectionProductCard`.
+ * @param props.cardSkeleton - Custom skeleton component; defaults to a vertical boxed `ProductCard.skeleton`.
+ * @param props.children - Additional content prepended inside the grid.
+ * @returns The product grid element, or `null` when there are no products and no children.
+ */
 const CollectionBlock = async <ComponentGeneric extends ElementType = 'div'>({
     as,
     children = null,
@@ -124,6 +142,16 @@ const CollectionBlock = async <ComponentGeneric extends ElementType = 'div'>({
 
 CollectionBlock.displayName = 'Nordcom.Products.CollectionBlock';
 
+/**
+ * Grid skeleton for a collection block, rendering `length` card skeleton placeholders.
+ *
+ * @param props.length - Number of skeleton cards to render; defaults to 7.
+ * @param props.isHorizontal - Applies horizontal rail layout classes when `true`.
+ * @param props.bare - When `true`, renders only the skeleton cards without a wrapper.
+ * @param props.className - Additional CSS class names for the wrapper element.
+ * @param props.cardSkeleton - Custom skeleton card component; defaults to `DefaultCardSkeleton`.
+ * @returns The skeleton grid element.
+ */
 CollectionBlock.skeleton = ({
     isHorizontal = false,
     bare = false,

--- a/apps/storefront/src/components/products/collection-product-card.tsx
+++ b/apps/storefront/src/components/products/collection-product-card.tsx
@@ -14,6 +14,16 @@ export type CollectionProductCardProps = {
     className?: string;
 };
 
+/**
+ * Renders a product card preconfigured with the `collection` surface preset.
+ *
+ * @param props.shop - Shop record forwarded to the product card.
+ * @param props.locale - Locale forwarded to the product card.
+ * @param props.data - Product to display.
+ * @param props.priority - When `true`, loads the card image eagerly.
+ * @param props.className - Additional CSS class names.
+ * @returns The `ProductCard` element.
+ */
 const CollectionProductCard = async (props: CollectionProductCardProps) => (
     <ProductCard {...SURFACE_PRESETS.collection} {...props} />
 );

--- a/apps/storefront/src/components/products/collection-view-all-tile.tsx
+++ b/apps/storefront/src/components/products/collection-view-all-tile.tsx
@@ -9,6 +9,13 @@ export type CollectionViewAllTileProps = {
     className?: string;
 };
 
+/**
+ * Card-sized tile linking to the full collection page, displayed after the product grid.
+ *
+ * @param props.collection - Collection providing handle and title for the link.
+ * @param props.className - Additional CSS class names.
+ * @returns The link tile element.
+ */
 const CollectionViewAllTile = ({ collection, className }: CollectionViewAllTileProps) => (
     <Link
         href={`/collections/${collection.handle}/`}

--- a/apps/storefront/src/components/products/info-lines.tsx
+++ b/apps/storefront/src/components/products/info-lines.tsx
@@ -16,6 +16,13 @@ export type StockStatusProps = {
     product?: Product;
     i18n: LocaleDictionary;
 } & Omit<HTMLProps<HTMLDivElement>, 'children'>;
+/**
+ * Displays an in-stock count badge or a back-order notice depending on variant availability.
+ *
+ * @param props.product - Product providing availability and inventory data.
+ * @param props.i18n - Locale dictionary for stock status labels.
+ * @returns The stock status section, or `null` when the product is absent or has no positive inventory.
+ */
 const StockStatus = ({ product, i18n, className, ...props }: StockStatusProps) => {
     const { t } = getTranslations('product', i18n);
     if (!product) {
@@ -67,6 +74,14 @@ export type GetOrderByEstimateProps = {
     processingTimeInDays: number;
 } & Omit<HTMLProps<HTMLDivElement>, 'children'>;
 
+/**
+ * Displays a dispatch-within estimate based on the shop's configured processing time.
+ *
+ * @param props.product - Product used to gate rendering; returns `null` when absent.
+ * @param props.i18n - Locale dictionary for the dispatch label.
+ * @param props.processingTimeInDays - Number of business days within which the order is dispatched.
+ * @returns The estimate section, or `null` when no product is provided.
+ */
 export const GetOrderByEstimate = ({
     product,
     i18n,
@@ -95,6 +110,15 @@ export type InfoLinesProps = {
     locale: Locale;
 } & Omit<HTMLProps<HTMLDivElement>, 'children'>;
 
+/**
+ * Async server component composing `StockStatus` and `GetOrderByEstimate` behind a feature flag.
+ *
+ * @param props.shop - Shop record used to evaluate the `productInfoLines` feature flag and read processing time.
+ * @param props.product - Product to display info lines for; returns `null` when absent.
+ * @param props.i18n - Locale dictionary forwarded to sub-components.
+ * @param props.locale - Locale forwarded to `GetOrderByEstimate`.
+ * @returns The info-lines container, or `null` when the product is absent or the flag is disabled.
+ */
 const InfoLines = async ({ shop, product, i18n, locale, className, ...props }: InfoLinesProps) => {
     // Inside cached subtree → .evaluate(shop). Trade-offs in defineFlag JSDoc.
     const productInfoLinesEnabled = productInfoLines.evaluate(shop);
@@ -122,6 +146,11 @@ const InfoLines = async ({ shop, product, i18n, locale, className, ...props }: I
 };
 InfoLines.displayName = 'Nordcom.Products.InfoLines';
 
+/**
+ * Placeholder skeleton for `InfoLines` while asynchronous data loads.
+ *
+ * @returns Two skeleton bar elements matching the typical info-lines layout.
+ */
 function infoLinesSkeleton() {
     return (
         <div className="flex w-full select-none flex-col items-start gap-4 empty:hidden">

--- a/apps/storefront/src/components/products/product-actions-container.tsx
+++ b/apps/storefront/src/components/products/product-actions-container.tsx
@@ -19,6 +19,12 @@ export type ProductActionsContainerProps = {
     i18n: LocaleDictionary;
 } & Omit<HTMLProps<HTMLDivElement>, 'children'>;
 
+/**
+ * Client component composing the quantity selector, option pickers, quantity breaks, and add-to-cart button.
+ *
+ * @param props.i18n - Locale dictionary forwarded to child action components.
+ * @returns The product actions container, or `null` when product or selected variant is unavailable.
+ */
 export const ProductActionsContainer = ({ className, i18n, ...props }: ProductActionsContainerProps) => {
     const { t } = getTranslations('common', i18n);
     const { quantity, setQuantity } = useQuantity();

--- a/apps/storefront/src/components/products/product-category.tsx
+++ b/apps/storefront/src/components/products/product-category.tsx
@@ -17,6 +17,16 @@ export type ProductCategoryProps = {
     className?: string;
 };
 
+/**
+ * Async server component rendering the product's type as a linked collection, falling back to plain text.
+ *
+ * @param props.shop - Shop record used to instantiate the Shopify API client.
+ * @param props.locale - Locale used for the API client.
+ * @param props.product - Product providing the `productType` to render.
+ * @param props.prefix - Optional node rendered before the category text.
+ * @param props.className - CSS class names applied to the collection link.
+ * @returns The category link element, or plain text when the collection cannot be fetched, or `null` when `productType` is absent.
+ */
 export async function ProductCategory({
     shop,
     locale,

--- a/apps/storefront/src/components/products/product-description.tsx
+++ b/apps/storefront/src/components/products/product-description.tsx
@@ -13,6 +13,14 @@ export type ProductDescriptionProps = {
     product: Product;
 } & Omit<ComponentPropsWithoutRef<'div'>, 'ref' | 'children' | 'prefix'>;
 
+/**
+ * Async server component rendering the product's HTML description and its original name.
+ *
+ * @param props.locale - Locale forwarded to the original-name sub-component.
+ * @param props.product - Product providing `handle` and `descriptionHtml`.
+ * @param props.className - Additional CSS class names applied to the card wrapper.
+ * @returns The description card element.
+ */
 async function Component({ locale, product, className, ...props }: ProductDescriptionProps) {
     const { handle, descriptionHtml } = product;
 
@@ -33,6 +41,12 @@ async function Component({ locale, product, className, ...props }: ProductDescri
 }
 
 export type ProductDescriptionSkeletonProps = {} & Omit<ComponentPropsWithoutRef<'div'>, 'ref' | 'children' | 'prefix'>;
+/**
+ * Skeleton placeholder for `ProductDescription` while server data loads.
+ *
+ * @param props.className - Additional CSS class names applied to the card wrapper.
+ * @returns The skeleton card element.
+ */
 function Skeleton({ className, ...props }: ProductDescriptionSkeletonProps) {
     return (
         <Card {...props} className={cn('flex flex-col gap-3', className)}>

--- a/apps/storefront/src/components/products/product-gallery.tsx
+++ b/apps/storefront/src/components/products/product-gallery.tsx
@@ -26,6 +26,20 @@ export type ProductGalleryProps = {
     product: Product;
     primaryImageClassName?: string;
 } & HTMLProps<HTMLDivElement>;
+/**
+ * Interactive image gallery with thumbnail strip and social share buttons.
+ *
+ * @param props.initialImageId - ID of the image to show on initial render; defaults to the first image.
+ * @param props.images - Array of Shopify images to display; returns `null` when empty.
+ * @param props.actions - Additional action nodes rendered alongside the share buttons.
+ * @param props.enableShare - When `true`, renders email and social share buttons.
+ * @param props.padding - When `true`, applies spacious inner padding to the primary image container.
+ * @param props.pageUrl - Canonical URL forwarded to the share buttons.
+ * @param props.i18n - Locale dictionary for share button labels.
+ * @param props.product - Product providing the SEO title used by share buttons.
+ * @param props.primaryImageClassName - Additional CSS class names applied to the primary image element.
+ * @returns The gallery section, or `null` when no images are provided.
+ */
 const ProductGallery = ({
     initialImageId,
     images,

--- a/apps/storefront/src/components/products/product-quantity-breaks.tsx
+++ b/apps/storefront/src/components/products/product-quantity-breaks.tsx
@@ -22,6 +22,16 @@ export type ProductQuantityBreaksItemProps = {
     discount?: number;
     className?: string;
 } & Omit<HTMLProps<HTMLButtonElement>, 'type' | 'children' | 'as'>;
+/**
+ * Selectable quantity-break tier button showing the minimum quantity, optional discount badge, and computed price.
+ *
+ * @param props.i18n - Locale dictionary for the savings badge label.
+ * @param props.minQuantity - Minimum quantity that activates this tier; also set as the cart quantity on click.
+ * @param props.maxQuantity - Maximum quantity for this tier; used to determine whether the tier is active.
+ * @param props.discount - Percentage discount applied to the unit price for this tier.
+ * @param props.className - Additional CSS class names.
+ * @returns The tier button element, or `null` when no variant price is available.
+ */
 export function ProductQuantityBreaksItem({
     i18n,
     minQuantity = 1,
@@ -94,6 +104,13 @@ export type ProductQuantityBreaksProps = {
     i18n: LocaleDictionary;
     disabled?: boolean;
 } & Omit<HTMLProps<HTMLDivElement>, 'type' | 'children' | 'as'>;
+/**
+ * Renders all quantity-break tiers for the currently selected variant.
+ *
+ * @param props.i18n - Locale dictionary forwarded to each tier item.
+ * @param props.disabled - When `true`, disables all tier buttons regardless of cart state.
+ * @returns The tier list section, or `null` when no variant or no breaks are defined.
+ */
 export function ProductQuantityBreaks({
     i18n,
     disabled = false,

--- a/apps/storefront/src/components/products/product-vendor.tsx
+++ b/apps/storefront/src/components/products/product-vendor.tsx
@@ -17,6 +17,16 @@ export type ProductVendorProps = {
     prefix?: ReactNode;
 } & Omit<ComponentPropsWithoutRef<'a'>, 'ref' | 'children' | 'prefix' | 'href'>;
 
+/**
+ * Async server component rendering the product vendor as a linked collection, falling back to plain text.
+ *
+ * @param props.shop - Shop record used to instantiate the Shopify API client.
+ * @param props.locale - Locale used for the API client.
+ * @param props.product - Product providing the vendor name.
+ * @param props.prefix - Optional node rendered before the vendor name.
+ * @param props.className - CSS class names applied to the link or wrapper element.
+ * @returns The vendor link, plain-text div, or `null` when `vendor` is absent.
+ */
 export async function ProductVendor({
     shop,
     locale,

--- a/apps/storefront/src/components/products/quantity-provider.tsx
+++ b/apps/storefront/src/components/products/quantity-provider.tsx
@@ -18,6 +18,14 @@ export interface QuantityContextValue extends QuantityProviderBase, QuantityCont
 
 export const QuantityContext = createContext<QuantityContextValue | null>(null);
 
+/**
+ * Provides quantity state to the product-page subtree via context.
+ *
+ * @param props.quantity - Current quantity value.
+ * @param props.setQuantity - Setter forwarded to consumers via context.
+ * @param props.children - Subtree that consumes the quantity context.
+ * @returns The context provider wrapping `children`.
+ */
 export function QuantityProvider({ children, quantity, setQuantity }: ShopProviderProps) {
     const value = useMemo(() => ({ quantity, setQuantity }), [quantity, setQuantity]);
 
@@ -25,6 +33,12 @@ export function QuantityProvider({ children, quantity, setQuantity }: ShopProvid
 }
 QuantityProvider.displayName = 'Nordcom.QuantityProvider';
 
+/**
+ * Returns the quantity context value from the nearest `QuantityProvider`.
+ *
+ * @returns The current `QuantityContextValue`.
+ * @throws {MissingContextProviderError} When called outside a `QuantityProvider`.
+ */
 export const useQuantity = (): QuantityContextValue => {
     const context = useContext(QuantityContext);
     if (!context) {

--- a/apps/storefront/src/components/products/quantity-selector.tsx
+++ b/apps/storefront/src/components/products/quantity-selector.tsx
@@ -12,6 +12,14 @@ import { getTranslations } from '@/utils/locale';
 import { safeParseFloat } from '@/utils/pricing';
 import { cn } from '@/utils/tailwind';
 
+/**
+ * Sanitizes a raw input string into a valid non-negative integer string clamped to `maxQuantity`.
+ *
+ * @param value - Raw string from the quantity input element.
+ * @param prev - Previous valid string used as fallback when `value` contains invalid characters.
+ * @param maxQuantity - Upper bound for the sanitized quantity value.
+ * @returns A sanitized non-negative integer string, or an empty string when `value` is blank.
+ */
 export const QuantityInputFilter = (
     value?: string,
     prev?: string,
@@ -47,6 +55,18 @@ export type QuantitySelectorProps = {
     inputClassName?: string;
 } & HTMLProps<HTMLDivElement>;
 
+/**
+ * Stepper control for entering a purchase quantity, with decrease/increase buttons and a validated text input.
+ *
+ * @param props.i18n - Locale dictionary for button and input accessible labels.
+ * @param props.value - Controlled quantity value; defaults to 0.
+ * @param props.update - Callback invoked with the validated new quantity on change.
+ * @param props.disabled - When `true`, disables all interactive elements regardless of cart state.
+ * @param props.allowDecreaseToZero - When `true`, permits decreasing the quantity to 0.
+ * @param props.buttonClassName - Additional CSS class names applied to the decrease and increase buttons.
+ * @param props.inputClassName - Additional CSS class names applied to the number input.
+ * @returns The quantity stepper element.
+ */
 const QuantitySelector = ({
     className,
     i18n,

--- a/apps/storefront/src/components/products/recommendation-product-card.tsx
+++ b/apps/storefront/src/components/products/recommendation-product-card.tsx
@@ -14,6 +14,16 @@ export type RecommendationProductCardProps = {
     className?: string;
 };
 
+/**
+ * Renders a product card preconfigured with the `recommendation` surface preset.
+ *
+ * @param props.shop - Shop record forwarded to the product card.
+ * @param props.locale - Locale forwarded to the product card.
+ * @param props.data - Product to display.
+ * @param props.priority - When `true`, loads the card image eagerly.
+ * @param props.className - Additional CSS class names.
+ * @returns The `ProductCard` element.
+ */
 const RecommendationProductCard = async (props: RecommendationProductCardProps) => (
     <ProductCard {...SURFACE_PRESETS.recommendation} {...props} />
 );

--- a/apps/storefront/src/components/products/recommended-products.tsx
+++ b/apps/storefront/src/components/products/recommended-products.tsx
@@ -18,6 +18,15 @@ export type RecommendedProductsProps = {
     product?: Product;
     className?: string;
 };
+/**
+ * Async server component that fetches Shopify product recommendations and renders them as a horizontal collection rail.
+ *
+ * @param props.shop - Shop record used to instantiate the Shopify API client.
+ * @param props.locale - Locale used for the API client.
+ * @param props.product - Source product whose recommendations are fetched; renders nothing when absent.
+ * @param props.className - Additional CSS class names forwarded to the collection block.
+ * @returns The horizontal collection block, or `null` when there is no product or the API call fails.
+ */
 async function Component({ shop, locale, product, className }: Readonly<RecommendedProductsProps>) {
     if (!product?.id) {
         return null;
@@ -44,6 +53,12 @@ async function Component({ shop, locale, product, className }: Readonly<Recommen
     );
 }
 
+/**
+ * Skeleton placeholder for `RecommendedProducts` while the async recommendation data loads.
+ *
+ * @param props.className - Additional CSS class names forwarded to the collection block skeleton.
+ * @returns The horizontal collection block skeleton element.
+ */
 function Skeleton({ className }: { className?: string }) {
     return <CollectionBlock.skeleton isHorizontal={true} className={className} />;
 }

--- a/apps/storefront/src/components/products/search-product-card.tsx
+++ b/apps/storefront/src/components/products/search-product-card.tsx
@@ -14,6 +14,16 @@ export type SearchProductCardProps = {
     className?: string;
 };
 
+/**
+ * Renders a product card preconfigured with the `search` surface preset.
+ *
+ * @param props.shop - Shop record forwarded to the product card.
+ * @param props.locale - Locale forwarded to the product card.
+ * @param props.data - Product to display.
+ * @param props.priority - When `true`, loads the card image eagerly.
+ * @param props.className - Additional CSS class names.
+ * @returns The `ProductCard` element.
+ */
 const SearchProductCard = async (props: SearchProductCardProps) => (
     <ProductCard {...SURFACE_PRESETS.search} {...props} />
 );

--- a/apps/storefront/src/components/providers-registry.tsx
+++ b/apps/storefront/src/components/providers-registry.tsx
@@ -13,12 +13,28 @@ import { useCartUtils } from '@/hooks/useCartUtils';
 import { BuildConfig } from '@/utils/build-config';
 import type { CurrencyCode, Locale } from '@/utils/locale';
 
+/**
+ * Mounts required cart utilities hooks inside a Suspense boundary without rendering visible content.
+ *
+ * @param props.locale - Locale forwarded to cart utilities.
+ * @param props.children - Optional children passed through unchanged.
+ * @returns The `children` node, or `null` when none are provided.
+ */
 const RequiredHooks = ({ locale, children = null }: { shop: OnlineShop; locale: Locale; children?: ReactNode }) => {
     void useCartUtils({ locale });
 
     return children;
 };
 
+/**
+ * Wraps children with the commerce provider that matches the shop's configured commerce provider type.
+ *
+ * @param props.shop - Shop record supplying the commerce provider configuration.
+ * @param props.locale - Locale used to configure country and language on the provider.
+ * @param props.children - Subtree that consumes commerce context.
+ * @returns The Shopify provider wrapping `children`, or a passthrough fragment when the domain is missing.
+ * @throws {UnknownCommerceProviderError} When the shop's commerce provider type is not supported.
+ */
 const CommerceProvider = ({ shop, locale, children }: { shop: OnlineShop; locale: Locale; children: ReactNode }) => {
     switch (shop.commerceProvider.type) {
         case 'shopify': {
@@ -51,6 +67,16 @@ const CommerceProvider = ({ shop, locale, children }: { shop: OnlineShop; locale
     }
 };
 
+/**
+ * Root client provider tree composing shop, commerce, cart utilities, live chat, and toast providers.
+ *
+ * @param props.shop - Shop record forwarded to every nested provider.
+ * @param props.currency - ISO currency code; defaults to `'USD'`.
+ * @param props.locale - Locale forwarded to every nested provider.
+ * @param props.children - Application subtree rendered inside the full provider stack.
+ * @param props.toolbars - When `true` (default), mounts the live-chat provider and toast notifications.
+ * @returns The composed provider tree wrapping `children`.
+ */
 const ProvidersRegistry = ({
     shop,
     currency = 'USD',

--- a/apps/storefront/src/components/shop/provider.tsx
+++ b/apps/storefront/src/components/shop/provider.tsx
@@ -29,6 +29,14 @@ export interface ShopContextValue extends ShopProviderBase, ShopContextReturns {
 
 export const ShopContext = createContext<ShopContextValue | null>(null);
 
+/**
+ * Makes shop, currency, and locale available to the client-side component tree.
+ *
+ * @param props.shop - The resolved `OnlineShop` record for the current tenant.
+ * @param props.currency - Active currency code; defaults to `'USD'`.
+ * @param props.locale - Active locale; defaults to `Locale.default`.
+ * @param props.children - Component subtree that will consume `ShopContext`.
+ */
 export function ShopProvider({ children, shop, currency = 'USD', locale = Locale.default }: ShopProviderProps) {
     const value = useMemo(() => ({ shop, currency, locale }), [shop, currency, locale]);
 
@@ -36,6 +44,12 @@ export function ShopProvider({ children, shop, currency = 'USD', locale = Locale
 }
 ShopProvider.displayName = 'Nordcom.ShopProvider';
 
+/**
+ * Returns the current `ShopContext` value.
+ *
+ * @returns The shop context containing shop, currency, and locale.
+ * @throws {MissingContextProviderError} When called outside of a `ShopProvider`.
+ */
 export const useShop = (): ShopContextValue => {
     const context = useContext(ShopContext);
     if (!context) {

--- a/apps/storefront/src/components/typography/content.tsx
+++ b/apps/storefront/src/components/typography/content.tsx
@@ -13,6 +13,18 @@ export type ContentProps<ComponentGeneric extends ElementType> = ContentPropsBas
         ? Omit<ComponentPropsWithoutRef<ComponentGeneric>, keyof ContentPropsBase<ComponentGeneric>>
         : ComponentPropsWithoutRef<ComponentGeneric>);
 
+/**
+ * Prose wrapper that applies Tailwind typography styles.
+ *
+ * Accepts either a pre-rendered `html` string (via `dangerouslySetInnerHTML`) or
+ * React `children`. Returns `null` when both are absent and no `as` override is given.
+ *
+ * @param props.as - Container element type; defaults to `div`.
+ * @param props.html - Raw HTML string rendered as inner HTML.
+ * @param props.children - React children used when `html` is not provided.
+ * @param props.className - Additional class names for the container.
+ * @returns The styled prose container, or `null` when no content is present.
+ */
 export const Content = <ComponentGeneric extends ElementType = 'div'>({
     as,
     className,

--- a/apps/storefront/src/components/typography/heading.tsx
+++ b/apps/storefront/src/components/typography/heading.tsx
@@ -8,6 +8,14 @@ export type TitleProps<T extends As> = {
     children?: ReactNode;
     bold?: boolean;
 } & ComponentProps<T>;
+/**
+ * Large page title with optional primary color and link hover styles.
+ *
+ * @param props.as - Heading element; defaults to `h1`. Pass `null` to render a plain Fragment.
+ * @param props.bold - When `true`, applies `font-bold text-primary` styles.
+ * @param props.children - Title text or nodes; returns `null` when absent.
+ * @returns The heading element, a Fragment, or `null`.
+ */
 export const Title = <T extends As>({ as: Tag = 'h1' as T, bold, className, key, ...props }: TitleProps<T>) => {
     if (!props.children) return null;
     if (Tag === null) {
@@ -35,6 +43,14 @@ export type SubTitleProps = {
     as?: ElementType | null;
     bold?: boolean;
 } & Omit<HTMLProps<HTMLDivElement>, 'as'>;
+/**
+ * Muted secondary subtitle rendered below a `Title`.
+ *
+ * @param props.as - Element type; defaults to `div`. Pass `null` to render a plain Fragment.
+ * @param props.bold - Applies `font-extrabold` when `true`.
+ * @param props.children - Subtitle text or nodes.
+ * @returns The subtitle element or a Fragment.
+ */
 export const SubTitle = ({ as, bold, className, key, ...props }: SubTitleProps) => {
     if (as === null) {
         return <Fragment key={key}>{props.children}</Fragment>;
@@ -84,6 +100,20 @@ type HeadingProps = {
     | SubPropFields
 );
 
+/**
+ * Composes `Title` and `SubTitle` into a stacked heading block.
+ *
+ * When only one of `title`/`subtitle` is provided the matching primitive is returned
+ * directly. When both are present they are wrapped in a flex column div (or a custom
+ * `wrapper` component), with order controlled by `reverse`.
+ *
+ * @param props.bold - Forwarded to both `Title` and `SubTitle`.
+ * @param props.title - Content for `Title`; omit to render only `SubTitle`.
+ * @param props.subtitle - Content for `SubTitle`; omit to render only `Title`.
+ * @param props.reverse - When `true`, renders `SubTitle` above `Title`.
+ * @param props.wrapper - Optional wrapper component that receives the heading set as children.
+ * @returns The composed heading, or `null` when neither title nor subtitle is provided.
+ */
 const Heading = ({ bold, ...props }: HeadingProps) => {
     let titleElement: ReactNode | null = null;
     if ('title' in props) {

--- a/apps/storefront/src/components/typography/label.tsx
+++ b/apps/storefront/src/components/typography/label.tsx
@@ -14,6 +14,14 @@ export type LabelProps<ComponentGeneric extends ElementType> = LabelPropsBase<Co
         ? Omit<ComponentPropsWithoutRef<ComponentGeneric>, keyof LabelPropsBase<ComponentGeneric>>
         : ComponentPropsWithoutRef<ComponentGeneric>);
 
+/**
+ * Small all-caps bold label for headings, field labels, and UI metadata.
+ *
+ * @param props.children - Label text or nodes; returns `null` when absent.
+ * @param props.as - Rendered element type; defaults to `p`.
+ * @param props.className - Additional class names.
+ * @returns The label element, or `null` when `children` is falsy.
+ */
 export const Label = <ComponentGeneric extends ElementType = 'p'>({
     children,
     as,

--- a/apps/storefront/src/components/typography/overview.tsx
+++ b/apps/storefront/src/components/typography/overview.tsx
@@ -20,6 +20,16 @@ export type OverviewProps = {
     accent?: Color;
 } & Omit<HTMLProps<HTMLDivElement>, 'children'>;
 
+/**
+ * Two-column image + content layout used for collection and page overviews.
+ *
+ * @param props.body - Rich content rendered inside the content card.
+ * @param props.image - Optional image metadata; without it only the content card is shown.
+ * @param props.imageStyle - `'normal'` uses `object-contain`, `'cover'` uses `object-cover`.
+ * @param props.layout - Side the image appears on (`'left'` | `'right'`), or `'center'` for stacked.
+ * @param props.accent - CSS color applied as `--accent-primary` on the image container.
+ * @returns The overview section, or `null` when `body` is absent.
+ */
 export const Overview = ({
     body,
     image,

--- a/apps/storefront/src/components/typography/pricing.tsx
+++ b/apps/storefront/src/components/typography/pricing.tsx
@@ -9,6 +9,14 @@ export type PricingProps = {
     price?: MoneyV2 | null;
     as?: ElementType;
 } & Omit<PriceProps & HTMLProps<HTMLDivElement>, 'children' | 'data' | 'as'>;
+/**
+ * Formats and renders a Shopify `MoneyV2` price with Suspense fallback.
+ *
+ * @param props.price - The monetary value to format; returns `null` when absent.
+ * @param props.as - Wrapper element type; defaults to `div`.
+ * @param props.className - Additional class names forwarded to `Price`.
+ * @returns A Suspense-wrapped `Price` element, or `null` when `price` is falsy.
+ */
 export const Pricing = ({ price, as: Tag = 'div', className, ...props }: PricingProps) => {
     if (!price) {
         return null;

--- a/apps/storefront/src/components/typography/shopify-content.tsx
+++ b/apps/storefront/src/components/typography/shopify-content.tsx
@@ -14,6 +14,15 @@ const DEFAULT_COMPONENTS: ToReactNodesOptions['components'] = {
     a: Link as ElementType,
 };
 
+/**
+ * Renders sanitized Shopify HTML as a React node tree.
+ *
+ * @param props.html - Raw HTML string from the Shopify storefront API.
+ * @param props.as - Wrapper element type; defaults to `div`.
+ * @param props.className - Additional class names applied to the wrapper.
+ * @param props.components - Override map for HTML element renderers passed to `toReactNodes`.
+ * @returns The rendered prose container, or `null` when `html` is empty.
+ */
 export const ShopifyContent = <ComponentGeneric extends ElementType = 'div'>({
     as,
     className,


### PR DESCRIPTION
Backfills Tier 2 JSDoc blocks on all exported and internal functions and React components under `apps/storefront/src/components/`.

Every block follows the project template: one-line purpose sentence, `@param` for each parameter, `@returns` where non-void, `@throws` where applicable. No `@example` blocks (Tier 2). Symbols that already had JSDoc were left untouched.

Changeset skipped — `apps/storefront` is in the changeset ignore list.