### PR TITLE
docs(storefront-utils): address jsdoc review followups

### DIFF
--- a/apps/storefront/src/utils/deep-equal.ts
+++ b/apps/storefront/src/utils/deep-equal.ts
@@ -1,8 +1,8 @@
 /**
  * Compares two values for deep equality using JSON serialization.
  *
- * @param a - First value.
- * @param b - Second value.
+ * @param a - Left-hand comparand; serialized via `JSON.stringify` before the equality check.
+ * @param b - Right-hand comparand; its serialized form is compared against `a`'s.
  * @returns `true` if both values serialize to identical JSON, otherwise `false`.
  */
 export function deepEqual<T>(a: T, b: T): boolean {

--- a/apps/storefront/src/utils/locale/weight.ts
+++ b/apps/storefront/src/utils/locale/weight.ts
@@ -94,7 +94,7 @@ export function localizeWeight(locale: Locale, weight: Weight, {}: LocalizeWeigh
  * Serializes a `Weight` to a compact human-readable string (e.g., `"500g"` or `"1.5kg"`), trimming trailing decimal zeros.
  *
  * @param props - The weight to format.
- * @param props.weight - The numeric weight value.
+ * @param props.weight - Numeric magnitude formatted to at most two decimal places with trailing zeros trimmed before the unit symbol is appended.
  * @param props.unit - The Shopify `WeightUnit` that determines the appended symbol.
  * @returns A string combining the trimmed numeric value and its unit symbol.
  */


### PR DESCRIPTION
Follow-up to PR #1993. Rewrites the three `@param` descriptions that were flagged as restatements during review:

- `deepEqual` `@param a` / `@param b`: now describe the JSON-serialization-based comparison contract rather than echoing the parameter names.
- `formatWeight` `@param props.weight`: now describes the magnitude's role in the formatted output (fixed-precision with trailing-zero trimming before unit symbol append) rather than restating the field name and type.

No logic changes.