### PR TITLE
docs(storefront-components): address jsdoc review followups

### DIFF
--- a/apps/storefront/src/components/geo-redirect.tsx
+++ b/apps/storefront/src/components/geo-redirect.tsx
@@ -22,7 +22,7 @@ const DISMISSED_KEY = 'geo-redirect-banner-dismissed';
 const subscribeToNothing = () => () => {};
 /** Returns the browser's primary language code in lowercase. */
 const getNavigatorLanguage = () => (navigator.language.split('-').at(0) || 'en').toLowerCase();
-/** Returns the current `navigator.userAgent` string. */
+/** Snapshot selector that exposes `navigator.userAgent` to `useSyncExternalStore` for crawler detection. */
 const getUserAgent = () => navigator.userAgent;
 /**
  * Reads and validates the geo-redirect banner dismissal timestamp from localStorage.

--- a/apps/storefront/src/components/link.tsx
+++ b/apps/storefront/src/components/link.tsx
@@ -17,7 +17,7 @@ export type LinkProps = {
 } & Omit<ComponentProps<typeof BaseLink>, 'locale'>;
 
 /**
- * Returns `true` when `href` should be treated as an internal link.
+ * Classifies `href` as internal by checking for a leading slash (relative path) or an exact protocol-plus-domain match against the current shop's domain.
  *
  * @param href - The URL string to check.
  * @param shop - Optional shop record used to detect self-referencing external URLs.

--- a/apps/storefront/src/components/typography/content.tsx
+++ b/apps/storefront/src/components/typography/content.tsx
@@ -16,14 +16,11 @@ export type ContentProps<ComponentGeneric extends ElementType> = ContentPropsBas
 /**
  * Prose wrapper that applies Tailwind typography styles.
  *
- * Accepts either a pre-rendered `html` string (via `dangerouslySetInnerHTML`) or
- * React `children`. Returns `null` when both are absent and no `as` override is given.
- *
  * @param props.as - Container element type; defaults to `div`.
  * @param props.html - Raw HTML string rendered as inner HTML.
  * @param props.children - React children used when `html` is not provided.
  * @param props.className - Additional class names for the container.
- * @returns The styled prose container, or `null` when no content is present.
+ * @returns The styled prose container, or `null` when neither `html` nor `children` is provided and `as` is not overridden.
  */
 export const Content = <ComponentGeneric extends ElementType = 'div'>({
     as,

--- a/apps/storefront/src/components/typography/heading.tsx
+++ b/apps/storefront/src/components/typography/heading.tsx
@@ -103,16 +103,12 @@ type HeadingProps = {
 /**
  * Composes `Title` and `SubTitle` into a stacked heading block.
  *
- * When only one of `title`/`subtitle` is provided the matching primitive is returned
- * directly. When both are present they are wrapped in a flex column div (or a custom
- * `wrapper` component), with order controlled by `reverse`.
- *
  * @param props.bold - Forwarded to both `Title` and `SubTitle`.
  * @param props.title - Content for `Title`; omit to render only `SubTitle`.
  * @param props.subtitle - Content for `SubTitle`; omit to render only `Title`.
  * @param props.reverse - When `true`, renders `SubTitle` above `Title`.
  * @param props.wrapper - Optional wrapper component that receives the heading set as children.
- * @returns The composed heading, or `null` when neither title nor subtitle is provided.
+ * @returns The matching primitive when only one of `title`/`subtitle` is provided; a flex column div (or `wrapper`) wrapping both when both are present; `null` when neither is given.
  */
 const Heading = ({ bold, ...props }: HeadingProps) => {
     let titleElement: ReactNode | null = null;


### PR DESCRIPTION
Follow-up to PR #1997. Addresses 4 JSDoc blockers in `apps/storefront/src/components/`:

- **`Content`** (`typography/content.tsx`): Collapsed multi-paragraph purpose to a single sentence; moved the `html`/`children` conditional rendering behavior into `@returns`.
- **`Heading`** (`typography/heading.tsx`): Same pattern — collapsed to one sentence; folded the single-prop short-circuit behavior into `@returns`.
- **`isInternal`** (`link.tsx`): Replaced purpose that restated the predicate name with a description of the actual classification criteria (leading slash or protocol-plus-domain match against shop domain).
- **`getUserAgent`** (`geo-redirect.tsx`): Replaced restatement with the function's actual role as a `useSyncExternalStore` snapshot selector for crawler detection.