### PR TITLE
docs(admin): address jsdoc review followups

### DIFF
--- a/apps/admin/src/components/cms/collection-table.tsx
+++ b/apps/admin/src/components/cms/collection-table.tsx
@@ -50,6 +50,10 @@ export type CollectionTableProps<TRow extends { id: string | number }> = {
  * `fn:<index>` for function-form accessors. Function accessors can't be
  * compared by identity across renders, but the column array is positional, so
  * the index is a sufficient discriminator.
+ *
+ * @param col - Column definition to generate a key for.
+ * @param index - Positional index in the columns array; used as the discriminator for function-form accessors.
+ * @returns The string accessor value, or `` `fn:${index}` `` for function-form accessors.
  */
 function columnKey<TRow>(col: Column<TRow>, index: number): string {
     return typeof col.accessor === 'function' ? `fn:${index}` : col.accessor;

--- a/apps/admin/src/utils/domains.ts
+++ b/apps/admin/src/utils/domains.ts
@@ -15,7 +15,7 @@ const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build';
 /**
  * Reads an env var by name and returns it, or logs an error in production and returns the fallback.
  *
- * @param envName - The environment variable name to read.
+ * @param envName - Which domain-host env var to look up; must be one of `'ADMIN_DOMAIN'` or `'LANDING_DOMAIN'`.
  * @param fallback - The default value returned when the env var is absent or empty.
  * @returns The resolved hostname string.
  */


### PR DESCRIPTION
## Summary
Addresses 2 reviewer blockers on merged PR #1996:
1. `requireOrFallback` `@param envName` rewritten to name the allowed env-var values instead of restating the name.
2. `columnKey` pre-existing JSDoc filled in with missing `@param`/`@returns`.

## Verification
- [x] typecheck
- [x] lint
- [x] rebased on origin/master
- [x] JSDoc-only diff