### PR TITLE
docs(storefront-api): address jsdoc review followups

### DIFF
--- a/apps/storefront/src/api/_normalize-payload.ts
+++ b/apps/storefront/src/api/_normalize-payload.ts
@@ -37,7 +37,7 @@ const LOCALE_SET = new Set<string>(cmsDefaultLocales);
 /**
  * Guards against arrays, `null`, and class instances, accepting only plain JS objects.
  *
- * @param v - Value to test.
+ * @param v - Value to discriminate; rejects `null`, arrays, and class instances that a bare `typeof v === 'object'` check would accept.
  * @returns `true` only when `v` is a non-null, non-array object literal.
  */
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>

--- a/apps/storefront/src/api/product.ts
+++ b/apps/storefront/src/api/product.ts
@@ -64,7 +64,7 @@ export type ProductFilters = SearchResultItemConnection['productFilters'];
 /**
  * Serializes a product's Shopify tracking parameters into a URL query string.
  *
- * @param options - Options object.
+ * @param options - Wraps a partial product to extract the tracking parameters field.
  * @param options.product - Product with optional `trackingParameters` field.
  * @returns A URL-encoded query string, or an empty string when no tracking parameters are present.
  */

--- a/apps/storefront/src/api/shopify/blog.ts
+++ b/apps/storefront/src/api/shopify/blog.ts
@@ -116,7 +116,7 @@ const BLOG_ARTICLE_QUERY = graphql(`
 /**
  * Fetches the list of all blogs from the Shopify Storefront API.
  *
- * @param options - Options object.
+ * @param options - Storefront API client wrapper for the query.
  * @param options.api - Storefront API client.
  * @returns A result tuple — `[Blog[], undefined]` on success or `[undefined, error]` on failure.
  */
@@ -139,7 +139,7 @@ export async function BlogsApi({ api }: { api: AbstractApi }): Promise<ApiReturn
 /**
  * Fetches a single blog and its articles from the Shopify Storefront API.
  *
- * @param options - Options object.
+ * @param options - Storefront API client and article-listing parameters; controls the blog handle, article count, sort key, and sort direction.
  * @param options.api - Storefront API client.
  * @param options.handle - Blog handle to fetch; defaults to `"news"`.
  * @param options.limit - Max articles to include; defaults to `30`.
@@ -189,7 +189,7 @@ export async function BlogApi({
 /**
  * Fetches a single blog article from the Shopify Storefront API.
  *
- * @param options - Options object.
+ * @param options - Storefront API client and article identifiers; selects the parent blog and article by handle.
  * @param options.api - Storefront API client.
  * @param options.blogHandle - Blog handle containing the article; defaults to `"news"`.
  * @param options.handle - Article handle to fetch.

--- a/apps/storefront/src/api/shopify/brand.ts
+++ b/apps/storefront/src/api/shopify/brand.ts
@@ -62,7 +62,7 @@ const BRAND_QUERY = graphql(`
 /**
  * Fetches the Shopify brand assets (logo, colors, cover image, slogan) for the active tenant.
  *
- * @param options - Options object.
+ * @param options - Storefront API client wrapper for the query.
  * @param options.api - Storefront API client.
  * @returns The brand object from the Shopify Storefront API.
  * @throws {ProviderFetchError} When the Storefront API returns errors.

--- a/apps/storefront/src/api/shopify/collection/api.ts
+++ b/apps/storefront/src/api/shopify/collection/api.ts
@@ -83,7 +83,7 @@ export const CollectionApi = async (
 /**
  * Fetches a lightweight list of all collections with product presence indicators.
  *
- * @param options - Options object.
+ * @param options - Storefront API client wrapper for the query.
  * @param options.api - Storefront API client.
  * @returns Array of collection stubs with `id`, `handle`, and `hasProducts`.
  * @throws {ProviderFetchError} When the Shopify query returns errors.

--- a/apps/storefront/src/api/shopify/collection/pagination.ts
+++ b/apps/storefront/src/api/shopify/collection/pagination.ts
@@ -36,6 +36,7 @@ type CollectionsFilters = {
  * @param defaultLimit - Fallback item count when no limit is specified; defaults to `30`.
  * @returns An object with `first`, `last`, or both, matching Shopify's cursor-pagination args.
  * @throws {TodoError} When both `limit` and `first`/`last` are provided simultaneously.
+ * @throws {UnreachableError} When the switch exhausts all cases without returning — indicates a caller passed a `LimitFilters` shape not covered by the current branches.
  */
 // TODO: This should be generic.
 export const extractLimitLikeFilters = (
@@ -96,7 +97,7 @@ type CollectionOptions = ApiOptions &
 /**
  * Counts all products in a collection across pages and returns per-page cursor positions.
  *
- * @param options - Options object.
+ * @param options - Storefront API client, collection handle, and pagination/sorting filters.
  * @param options.api - Storefront API client.
  * @param options.handle - Collection handle to paginate.
  * @returns Object with total `pages`, total `products`, and `cursors` array for cursor-based navigation.
@@ -186,7 +187,7 @@ type CollectionsOptions = ApiOptions &
 /**
  * Fetches a paginated slice of collections from the Shopify Storefront API.
  *
- * @param options - Options object.
+ * @param options - Storefront API client and pagination/sorting filters for the collections slice.
  * @param options.api - Storefront API client.
  * @param options.filters - Sorting and cursor constraints for the page request.
  * @returns Object with `collections` edges and `page_info` cursor metadata.

--- a/apps/storefront/src/api/shopify/page.ts
+++ b/apps/storefront/src/api/shopify/page.ts
@@ -91,7 +91,7 @@ function normalize(page: PageFields): NormalizedShopifyPage {
 /**
  * Fetches a single Shopify page by handle.
  *
- * @param options - Options object.
+ * @param options - Storefront API client and the page handle to fetch.
  * @param options.api - Storefront API client.
  * @param options.handle - Page handle to fetch.
  * @returns A result tuple — `[NormalizedShopifyPage, undefined]` on success or `[undefined, error]` on failure.
@@ -124,7 +124,7 @@ export async function ShopifyPageApi({
 /**
  * Recursively fetches all Shopify pages, paginating until exhausted.
  *
- * @param options - Options object.
+ * @param options - Storefront API client and accumulated pagination state from previous recursive calls.
  * @param options.api - Storefront API client.
  * @param options.cursor - Pagination cursor for the next page; omitted on the first call.
  * @param options.pages - Accumulated results from previous pages; omitted on the first call.

--- a/apps/storefront/src/api/shopify/product/api.ts
+++ b/apps/storefront/src/api/shopify/product/api.ts
@@ -25,7 +25,7 @@ type ProductOptions = ApiOptions &
 /**
  * Fetches a single product from the Shopify Storefront API by handle.
  *
- * @param options - Options object.
+ * @param options - Storefront API client, product handle, and optional GraphQL fragment override.
  * @param options.api - Storefront API client.
  * @param options.handle - Product handle to fetch.
  * @param options.fragment - Optional GraphQL fragment string to override the default product fields.
@@ -86,7 +86,7 @@ export const ProductApi = async ({ api, handle, fragment }: ProductOptions): Pro
 /**
  * Fetches a paginated list of products from the Shopify Storefront API.
  *
- * @param options - Options object.
+ * @param options - Storefront API client and pagination parameters; controls page size, sort key, and cursor position.
  * @param options.api - Storefront API client.
  * @param options.limit - Max products per page; defaults to `250`.
  * @param options.sorting - Product sort key; defaults to `"BEST_SELLING"`.

--- a/apps/storefront/src/api/shopify/product/pagination.ts
+++ b/apps/storefront/src/api/shopify/product/pagination.ts
@@ -53,7 +53,7 @@ export type ProductsOptions = ApiOptions & {
 /**
  * Counts all products matching the filters across pages and returns per-page cursor positions.
  *
- * @param options - Options object.
+ * @param options - Storefront API client and pagination/sorting constraints for the count traversal.
  * @param options.api - Storefront API client.
  * @param options.filters - Pagination and sorting constraints.
  * @returns Object with total `pages`, total `products`, and `cursors` for cursor-based navigation.

--- a/apps/storefront/src/api/shopify/recommendation.ts
+++ b/apps/storefront/src/api/shopify/recommendation.ts
@@ -27,7 +27,7 @@ const PRODUCT_RECOMMENDATIONS_QUERY = graphql(
 /**
  * Fetches related product recommendations from Shopify for a given product GID.
  *
- * @param options - Options object.
+ * @param options - Storefront API client and the product GID to fetch recommendations for.
  * @param options.api - Storefront API client.
  * @param options.id - Shopify product GID (e.g. `"gid://shopify/Product/123"`).
  * @returns Array of recommended products.

--- a/apps/storefront/src/api/shopify/search.ts
+++ b/apps/storefront/src/api/shopify/search.ts
@@ -49,7 +49,7 @@ export const SEARCH_PRODUCTS_QUERY = graphql(
 /**
  * Searches Shopify products by query string and returns matching products, filters, and total count.
  *
- * @param options - Options object.
+ * @param options - Storefront API client and search parameters; drives the query string and result limit.
  * @param options.client - Storefront API client.
  * @param options.query - Search query string; returns an empty result when blank.
  * @param [options.limit] - Maximum number of results to return; defaults to 75.
@@ -106,7 +106,7 @@ export const SearchApi = async ({
 /**
  * Cached variant of `SearchApi` — resolves shop and locale from their identifiers and delegates to `SearchApi`.
  *
- * @param options - Options object.
+ * @param options - Shop and locale identifiers used to resolve the API client, plus the search query string and cache-key discriminators.
  * @param options.shopId - Shop ID for cache tagging.
  * @param options.shopDomain - Shop domain used to resolve the shop record.
  * @param options.localeCode - Locale code used to resolve the locale.

--- a/apps/storefront/src/api/shopify/vendor.ts
+++ b/apps/storefront/src/api/shopify/vendor.ts
@@ -54,7 +54,7 @@ type VendorsOptions = { api: AbstractApi };
 /**
  * Get all vendors from Shopify.
  *
- * @param options - Options object.
+ * @param options - Storefront API client wrapper for the query.
  * @param options.api - Storefront API client.
  * @returns The list of vendors.
  * @throws {ProviderFetchError} When the Shopify query returns errors.

--- a/apps/storefront/src/api/store.ts
+++ b/apps/storefront/src/api/store.ts
@@ -78,7 +78,7 @@ const DEFAULT_LOCALE = {
 /**
  * Fetches available countries and their languages from the Shopify Storefront API.
  *
- * @param options - Options object.
+ * @param options - Storefront API client wrapper for the query.
  * @param options.api - Storefront API client.
  * @returns Array of available countries; falls back to a US default when the API returns nothing.
  */
@@ -104,7 +104,7 @@ export const CountriesApi = async ({ api }: { api: AbstractApi }): Promise<Count
 /**
  * Derives all supported locales for the shop from the available countries.
  *
- * @param options - Options object.
+ * @param options - Storefront API client wrapper for the query.
  * @param options.api - Storefront API client.
  * @returns Array of supported locales.
  * @throws {NoLocalesAvailableError} When no locales can be derived from the available countries.
@@ -132,7 +132,7 @@ export const LocalesApi = async ({ api }: { api: AbstractApi }): Promise<Locale[
 /**
  * Fetches the current localization context (country and language) from the Shopify Storefront API.
  *
- * @param options - Options object.
+ * @param options - Storefront API client wrapper for the query.
  * @param options.api - Storefront API client.
  * @returns Localization object, or `null` when the shop does not use Shopify as its commerce provider.
  * @throws {ProviderFetchError} When the Shopify query returns errors.
@@ -165,7 +165,7 @@ export const LocaleApi = async ({ api }: { api: AbstractApi }) => {
 /**
  * Fetches payment settings for the shop from the Shopify Storefront API.
  *
- * @param options - Options object.
+ * @param options - Storefront API client wrapper for the query.
  * @param options.api - Storefront API client.
  * @returns Payment settings subset, or `null` when the shop does not use Shopify or the query returns no data.
  */
@@ -207,7 +207,7 @@ export type BusinessDataApiArgs = { shop: OnlineShop; locale: Locale };
  * `null` when the doc has not been seeded — InfoBar / Footer call sites
  * collapse to no-render in that case.
  *
- * @param options - Options object.
+ * @param options - Tenant shop record and locale used to scope the Payload CMS fetch.
  * @param options.shop - Shop record identifying the tenant.
  * @param options.locale - Locale used for payload normalization.
  * @returns Normalized business data, or `null` when the doc has not been seeded.


### PR DESCRIPTION
Follow-up to PR #1994. Addresses three blocker categories raised in review.

**1. `extractLimitLikeFilters` `@throws`** — Added missing `@throws {UnreachableError}` for the exhaustive-switch escape hatch at the end of the function. Only `{TodoError}` was documented; the unreachable path was silently unaccounted for.

**2. `isPlainObject` `@param v`** — Rewrote the restatement-antipattern description (`Value to test.`) to explain what the guard actually rejects that a bare `typeof v === 'object'` check would pass through: `null`, arrays, and class instances.

**3. Systemic `@param options - Options object.`** — Replaced 22 instances across 13 files with descriptions that name what the options actually carry (API client, pagination/sorting filters, tenant + locale identifiers, etc.). Files touched: `blog.ts`, `store.ts`, `product.ts`, `vendor.ts`, `recommendation.ts`, `page.ts`, `brand.ts`, `search.ts`, `collection/api.ts`, `collection/pagination.ts`, `product/api.ts`, `product/pagination.ts`, `_normalize-payload.ts`.