### PR TITLE
docs(storefront-other): address jsdoc review followups

### DIFF
--- a/apps/storefront/src/app/[domain]/[locale]/_actions/cart.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/_actions/cart.ts
@@ -5,63 +5,63 @@ import { forms, typed } from '@/cart/kernel';
 /**
  * Server Action: adds a line item to the active cart.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const addLine = typed.addLine;
 
 /**
  * Server Action: updates the quantity of an existing cart line item.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const updateLine = typed.updateLine;
 
 /**
  * Server Action: removes a line item from the active cart.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const removeLine = typed.removeLine;
 
 /**
  * Server Action: applies a discount code to the active cart.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const applyDiscountCode = typed.applyDiscountCode;
 
 /**
  * Server Action: removes a discount code from the active cart.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const removeDiscountCode = typed.removeDiscountCode;
 
 /**
  * Server Action: applies a gift card to the active cart.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const applyGiftCard = typed.applyGiftCard;
 
 /**
  * Server Action: removes a gift card from the active cart.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const removeGiftCard = typed.removeGiftCard;
 
 /**
  * Server Action: updates the order note on the active cart.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const updateNote = typed.updateNote;
 
 /**
  * Server Action: updates the custom attributes on the active cart.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const updateAttributes = typed.updateAttributes;
 
@@ -70,7 +70,7 @@ export const updateAttributes = typed.updateAttributes;
  * code, etc.) on the active cart so the cart is associated with the signed-in
  * customer.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const updateBuyerIdentity = typed.updateBuyerIdentity;
 
@@ -78,76 +78,76 @@ export const updateBuyerIdentity = typed.updateBuyerIdentity;
  * Server Action: dispatches a raw mutation envelope to the cart kernel,
  * allowing callers to submit any registered mutation by name.
  *
- * @throws {Error} When the mutation fails or the kernel does not recognise the mutation name.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const dispatch = typed.dispatch;
 
 /**
  * Server Action (form-compatible): adds a line item from a `FormData` submission.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const addLineAction = forms.addLineAction;
 
 /**
  * Server Action (form-compatible): updates a cart line item quantity from a `FormData` submission.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const updateLineAction = forms.updateLineAction;
 
 /**
  * Server Action (form-compatible): removes a line item from a `FormData` submission.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const removeLineAction = forms.removeLineAction;
 
 /**
  * Server Action (form-compatible): applies a discount code from a `FormData` submission.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const applyDiscountCodeAction = forms.applyDiscountCodeAction;
 
 /**
  * Server Action (form-compatible): removes a discount code from a `FormData` submission.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const removeDiscountCodeAction = forms.removeDiscountCodeAction;
 
 /**
  * Server Action (form-compatible): applies a gift card from a `FormData` submission.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const applyGiftCardAction = forms.applyGiftCardAction;
 
 /**
  * Server Action (form-compatible): removes a gift card from a `FormData` submission.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const removeGiftCardAction = forms.removeGiftCardAction;
 
 /**
  * Server Action (form-compatible): updates the order note from a `FormData` submission.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const updateNoteAction = forms.updateNoteAction;
 
 /**
  * Server Action (form-compatible): updates cart attributes from a `FormData` submission.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const updateAttributesAction = forms.updateAttributesAction;
 
 /**
  * Server Action (form-compatible): updates buyer identity from a `FormData` submission.
  *
- * @throws {Error} When the Shopify cart mutation fails or the transport layer throws.
+ * @throws {CartProviderError} When the request context cannot be resolved for the active tenant.
  */
 export const updateBuyerIdentityAction = forms.updateBuyerIdentityAction;

--- a/apps/storefront/src/app/[domain]/[locale]/blogs/[blog]/[handle]/static-params.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/blogs/[blog]/[handle]/static-params.ts
@@ -16,7 +16,7 @@ export type ArticlePageParams = Promise<{ domain: string; locale: string; blog: 
  *
  * @param params - The already-resolved `domain`, `locale`, and `blog` handle from the parent segments.
  * @returns An array of `{ handle }` objects, one per article in the blog.
- * @throws When a non-404 Shopify error is encountered during article enumeration.
+ * @throws {unknown} When a non-404 Shopify error is encountered during article enumeration.
  */
 export async function generateStaticParams({
     params,

--- a/apps/storefront/src/app/[domain]/[locale]/blogs/[blog]/static-params.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/blogs/[blog]/static-params.ts
@@ -17,7 +17,7 @@ export type BlogPageParams = Promise<{ domain: string; locale: string; blog: str
  *
  * @param params - The already-resolved `domain` and `locale` from the parent segment.
  * @returns An array of `{ blog }` objects, one per blog in the shop.
- * @throws When a non-404 Shopify error is encountered during blog enumeration.
+ * @throws {unknown} When a non-404 Shopify error is encountered during blog enumeration.
  */
 export async function generateStaticParams({
     params,

--- a/apps/storefront/src/app/[domain]/[locale]/collections/[handle]/static-params.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/collections/[handle]/static-params.ts
@@ -15,7 +15,7 @@ export type CollectionPageParams = Promise<{ domain: string; locale: string; han
  *
  * @param params - The already-resolved `domain` and `locale` from the parent segment.
  * @returns An array of `{ handle }` objects, one per collection.
- * @throws When a non-404 Shopify error is encountered during collection enumeration.
+ * @throws {unknown} When a non-404 Shopify error is encountered during collection enumeration.
  */
 export async function generateStaticParams({
     params,

--- a/apps/storefront/src/app/[domain]/[locale]/products/[handle]/static-params.ts
+++ b/apps/storefront/src/app/[domain]/[locale]/products/[handle]/static-params.ts
@@ -19,7 +19,7 @@ export type ProductPageParams = Promise<{ domain: string; locale: string; handle
  *
  * @param params - The already-resolved `domain` and `locale` from the parent segment.
  * @returns An array of `{ handle }` objects for pre-rendered products.
- * @throws When a non-404 Shopify error is encountered during product enumeration.
+ * @throws {unknown} When a non-404 Shopify error is encountered during product enumeration.
  */
 export async function generateStaticParams({
     params,

--- a/apps/storefront/src/middleware/storefront.ts
+++ b/apps/storefront/src/middleware/storefront.ts
@@ -182,6 +182,7 @@ const LOCALE_SLASH_TEST = /\/([a-zA-Z]{2}-[a-zA-Z]{2})\//g;
  *
  * @param req - The incoming Next.js edge request.
  * @returns A redirect, rewrite, or error response depending on tenant and locale resolution.
+ * @throws {NoLocaleResolvableError} When no supported locale can be resolved for the request URL.
  */
 export const storefront = async (req: NextRequest): Promise<NextResponse> => {
     let newUrl = req.nextUrl.clone();


### PR DESCRIPTION
Addresses the 1 blocker and 2 quality notes from the PR #1995 review.

## Fix 1 — BLOCKER: `storefront` missing `@throws`

Added `@throws {NoLocaleResolvableError} When no supported locale can be resolved for the request URL.` to the `storefront` function in `apps/storefront/src/middleware/storefront.ts`. The throw at line 276 was already present but undocumented.

## Fix 2 — cart actions `@throws {Error}` → `@throws {CartProviderError}`

All 21 server actions in `apps/storefront/src/app/[domain]/[locale]/_actions/cart.ts` used the generic `@throws {Error}`. After tracing the full call path:

- The typed actions delegate to `createTypedCartActions` (`@nordcom/cart-next`), whose `run()` helper wraps `kernel.mutate()` in a try-catch that converts every kernel error (`CartUserError`, `CartNotFoundError`, `CartCapabilityUnsupportedError`, retried `CartProviderError`) into a `CartActionResult` discriminated-union return value — none of those bubble.
- The **only** escape path is `resolveContext()`, called before the try block, which throws `CartProviderError` when the storefront cannot determine shop + locale from the request context (e.g. middleware header not set).
- Form actions delegate to the typed actions and share the same escape path.

All 21 annotations are updated to `@throws {CartProviderError} When the request context cannot be resolved for the active tenant.`

## Fix 3 — static-params bare `@throws` → `@throws {unknown}`

Four `generateStaticParams` functions had `@throws When ...` without a type annotation. Updated to `@throws {unknown} When ...` per the spec (re-thrown caught unknowns where the concrete class is not known at the call site):
- `blogs/[blog]/[handle]/static-params.ts`
- `blogs/[blog]/static-params.ts`
- `collections/[handle]/static-params.ts`
- `products/[handle]/static-params.ts`