### PR TITLE
docs(landing): backfill jsdoc on functions and components

### DIFF
--- a/apps/landing/src/app/(marketing)/news/[year]/[month]/[slug]/articles.ts
+++ b/apps/landing/src/app/(marketing)/news/[year]/[month]/[slug]/articles.ts
@@ -21,6 +21,11 @@ const SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,254}[a-z0-9])?$/;
 const isValidArticleParams = ({ year, month, slug }: { year: string; month: string; slug: string }): boolean =>
     YEAR_RE.test(year) && MONTH_RE.test(month) && SLUG_RE.test(slug);
 
+/**
+ * Returns the URL segment params for every Markdown article discovered on disk.
+ *
+ * @returns Array of `{ year, month, slug }` objects suitable for `generateStaticParams`.
+ */
 export async function getArticlePaths() {
     return POST_PATHS.map((postPath) => {
         const slug = path.basename(postPath, path.extname(postPath));
@@ -35,6 +40,17 @@ export async function getArticlePaths() {
     });
 }
 
+/**
+ * Reads and parses a single Markdown article identified by its URL segments.
+ *
+ * Validates param shape and that the resolved file path stays inside the articles directory
+ * before any filesystem access, preventing path-traversal via percent-encoded sequences.
+ *
+ * @param year - Four-digit year string from the URL segment.
+ * @param month - One- or two-digit month string from the URL segment.
+ * @param slug - Lowercase alphanumeric slug from the URL segment.
+ * @returns Parsed Markdoc content tree and front-matter metadata, or `null` when params are invalid or the file is absent.
+ */
 export async function getArticleContent({ year, month, slug }: { year: string; month: string; slug: string }) {
     if (!isValidArticleParams({ year, month, slug })) return null;
     const filePath = path.resolve(POSTS_DIR, year, month, `${slug}.md`);
@@ -65,6 +81,11 @@ export async function getArticleContent({ year, month, slug }: { year: string; m
     };
 }
 
+/**
+ * Loads all articles and returns them sorted newest-first by publication date.
+ *
+ * @returns Array of article records, each containing URL segment params and front-matter metadata, sorted descending by date.
+ */
 export async function getArticles() {
     const paths = await getArticlePaths();
     const articles = (

--- a/apps/landing/src/components/back-button.tsx
+++ b/apps/landing/src/components/back-button.tsx
@@ -6,6 +6,11 @@ import { BiChevronLeft } from 'react-icons/bi';
 export type BackButtonProps = {
     href: string;
 } & HTMLProps<HTMLDivElement>;
+/**
+ * Renders a chevron-left "Back" link for navigating up from a detail page.
+ *
+ * @param props.href - Destination URL for the back navigation link.
+ */
 export default function BackButton({ href }: BackButtonProps) {
     return (
         <Label className="flex items-center justify-start gap-[0.15rem] text-base" as={Link} href={href}>

--- a/apps/landing/src/components/content.tsx
+++ b/apps/landing/src/components/content.tsx
@@ -4,6 +4,13 @@ export type ContentProps<T extends ElementType = 'article'> = {
     children?: ReactNode;
     as?: T;
 } & Omit<ComponentProps<T>, 'as'>;
+/**
+ * Renders Markdoc prose content with consistent typography and brand-color styles applied.
+ *
+ * @param props.children - Rendered content nodes.
+ * @param props.as - HTML element or component to render as; defaults to `article`.
+ * @param props.className - Additional CSS classes merged onto the root element.
+ */
 export const Content = <T extends ElementType = 'article'>({ children, as, className, ...props }: ContentProps<T>) => {
     const AsComponent: ElementType = as || 'article';
 

--- a/apps/landing/src/components/footer.tsx
+++ b/apps/landing/src/components/footer.tsx
@@ -6,6 +6,11 @@ import { cn } from '@/utils/tailwind';
 const CURRENT_YEAR = new Date().getFullYear();
 
 export type FooterProps = {} & Omit<HTMLProps<HTMLDivElement>, 'children'>;
+/**
+ * Renders the site footer with legal links, copyright notice, and the deployed git commit hash when available.
+ *
+ * @param props.className - Additional CSS classes merged onto the `<footer>` element.
+ */
 export default function Footer({ className, ...props }: FooterProps) {
     return (
         <footer

--- a/apps/landing/src/components/header.tsx
+++ b/apps/landing/src/components/header.tsx
@@ -7,6 +7,11 @@ import { getAdminHostname } from '@/utils/domains';
 import { cn } from '@/utils/tailwind';
 
 export type HeaderProps = {} & Omit<HTMLProps<HTMLDivElement>, 'children' | 'color'>;
+/**
+ * Renders the site navigation header with the Nordcom Commerce logo, nav links, and an Admin portal CTA.
+ *
+ * @param props.className - Additional CSS classes merged onto the header root element.
+ */
 export default async function Header({ className, ...props }: HeaderProps) {
     return (
         <NordstarHeader {...props} className={cn('[grid-area:header]', className)}>

--- a/apps/landing/src/components/providers.tsx
+++ b/apps/landing/src/components/providers.tsx
@@ -13,10 +13,14 @@ import { Toaster } from 'sonner';
 
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID;
 
-// https://github.com/TheSGJ/nextjs-toploader/issues/56#issuecomment-1820484781
-// Isolated in its own component (and Suspense-wrapped below) so the dynamic
-// usePathname() read doesn't force <Providers> itself to opt out of prerender
-// under Next 16's cacheComponents:true.
+/**
+ * Signals NProgress completion on every client-side route change.
+ *
+ * Isolated so that the `usePathname()` subscription does not force the parent
+ * `<Providers>` tree to opt out of prerender under Next 16's `cacheComponents: true`.
+ *
+ * @see https://github.com/TheSGJ/nextjs-toploader/issues/56#issuecomment-1820484781
+ */
 function CompleteProgressOnRouteChange() {
     const pathname = usePathname();
     useEffect(() => {
@@ -29,6 +33,11 @@ function CompleteProgressOnRouteChange() {
 export type ProvidersProps = {
     children: ReactNode;
 };
+/**
+ * Wraps the application with the Nordstar theme provider, top-loader, toast notifications, and Google Tag Manager.
+ *
+ * @param props.children - The application subtree to wrap.
+ */
 export function Providers({ children }: ProvidersProps) {
     return (
         <NordstarProvider theme={Theme} className="block">

--- a/apps/landing/src/middleware/admin.ts
+++ b/apps/landing/src/middleware/admin.ts
@@ -4,6 +4,16 @@ import { NextResponse } from 'next/server';
 
 export const ADMIN_HOSTNAME = process.env.ADMIN_DOMAIN ?? 'admin.localhost';
 
+/**
+ * Rewrites an `/admin/*` request to the admin application hostname.
+ *
+ * Strips the leading `/admin` path segment, forwards the originating shop hostname
+ * via `?shop` and the `x-nordcom-shop` header, and injects the Vercel protection-bypass
+ * secret when configured.
+ *
+ * @param req - Incoming Next.js middleware request.
+ * @returns A rewrite response targeting the admin hostname.
+ */
 export const admin = async (req: NextRequest): Promise<NextResponse> => {
     const url = req.nextUrl.clone();
     const newUrl = url.clone();

--- a/apps/landing/src/proxy.ts
+++ b/apps/landing/src/proxy.ts
@@ -10,6 +10,15 @@ export const config = {
     ],
 };
 
+/**
+ * Entry-point middleware that dispatches requests to the appropriate sub-handler.
+ *
+ * Currently routes `/admin/*` traffic to the admin rewrite handler; all other
+ * requests pass through unmodified.
+ *
+ * @param req - Incoming Next.js middleware request.
+ * @returns A rewrite response for admin routes, or a pass-through response otherwise.
+ */
 export default async function proxy(req: NextRequest) {
     const url = req.nextUrl.clone();
     const pathname = url.pathname;

--- a/apps/landing/src/utils/domains.ts
+++ b/apps/landing/src/utils/domains.ts
@@ -1,5 +1,11 @@
 import { MissingEnvironmentVariableError } from '@nordcom/commerce-errors';
 
+/**
+ * Returns the configured service domain from the `SERVICE_DOMAIN` environment variable.
+ *
+ * @returns The bare domain string (no scheme or trailing slash).
+ * @throws {MissingEnvironmentVariableError} When `SERVICE_DOMAIN` is not set.
+ */
 export function getServiceDomain(): string {
     const domain = process.env.SERVICE_DOMAIN;
     if (!domain) {
@@ -8,10 +14,22 @@ export function getServiceDomain(): string {
     return domain;
 }
 
+/**
+ * Returns the fully-qualified HTTPS URL for the service.
+ *
+ * @returns URL string in the form `https://<SERVICE_DOMAIN>`.
+ * @throws {MissingEnvironmentVariableError} When `SERVICE_DOMAIN` is not set.
+ */
 export function getServiceUrl(): string {
     return `https://${getServiceDomain()}`;
 }
 
+/**
+ * Returns the admin sub-domain hostname derived from the service domain.
+ *
+ * @returns Hostname string in the form `admin.<SERVICE_DOMAIN>`.
+ * @throws {MissingEnvironmentVariableError} When `SERVICE_DOMAIN` is not set.
+ */
 export function getAdminHostname(): string {
     return `admin.${getServiceDomain()}`;
 }

--- a/apps/landing/src/utils/tailwind.ts
+++ b/apps/landing/src/utils/tailwind.ts
@@ -1,6 +1,12 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+/**
+ * Merges Tailwind CSS class names, resolving conflicts via `tailwind-merge`.
+ *
+ * @param inputs - One or more class values accepted by `clsx` (strings, arrays, conditionals).
+ * @returns A single deduplicated, conflict-resolved class string.
+ */
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
## Summary
Adds JSDoc to all in-scope symbols in `apps/landing` per [spec](.specs/2026-05-27-jsdoc-coverage-retrofit/spec.md).

## Counts
- Tier-1 symbols documented: 0
- Tier-2 symbols documented: 15
- Files touched: 10

## Verification
- [x] `pnpm --filter @nordcom/commerce-landing typecheck` passes
- [x] `pnpm --filter @nordcom/commerce-landing lint` passes
- [x] Rebased onto latest `origin/master`
- [x] Diff is JSDoc-only (no logic changes)