### PR TITLE
perf(db): index alternativeDomains and add a field projection to find…

### DIFF
--- a/apps/storefront/src/api/shopify/collection/pagination.ts
+++ b/apps/storefront/src/api/shopify/collection/pagination.ts
@@ -120,12 +120,18 @@ export const CollectionPaginationCountApi = async ({
     const filters = 'filters' in props ? props.filters : /** @deprecated */ (props as CollectionFilters);
     const filtersTag = JSON.stringify(filters, null, 0);
 
-    const countProducts = async (count: number = 0, cursors: string[] = [], after: string | null = null) => {
+    // Walk the collection at Shopify's max page size rather than the grid's display size. Relay
+    // edge cursors are position-stable across page sizes for a given sort key, so harvesting every
+    // cursor from a wide walk lets us reconstruct the narrow per-page boundaries while issuing
+    // ~12x fewer serial round-trips (a 400-product collection drops from ~19 calls to 2).
+    const TRAVERSAL_PAGE_SIZE = 250;
+
+    const collectCursors = async (allCursors: string[] = [], after: string | null = null): Promise<string[]> => {
         const { data, errors } = await api.query(
             COLLECTION_PAGINATION_COUNT_QUERY,
             {
                 handle,
-                ...extractLimitLikeFilters(filters),
+                first: TRAVERSAL_PAGE_SIZE,
                 ...(({ sorting = 'COLLECTION_DEFAULT' }) => ({
                     sorting,
                     after,
@@ -145,33 +151,39 @@ export const CollectionPaginationCountApi = async ({
 
         if (errors && errors.length > 0) {
             throw new ProviderFetchError(errors);
-        } else if (!data?.collection?.products.edges || data.collection.products.edges.length <= 0) {
-            return {
-                count,
-                cursors,
-            };
         }
 
-        const cursor = data.collection.products.edges.at(-1)?.cursor ?? '';
-        if (data.collection.products.pageInfo.hasNextPage) {
-            const res = await countProducts(count, [cursor, ...cursors], cursor);
-
-            count += res.count;
-            cursors = res.cursors;
+        const products = data?.collection?.products;
+        const edges = products?.edges;
+        if (!edges || edges.length <= 0) {
+            return allCursors;
         }
 
-        return {
-            count: count + data.collection.products.edges.length,
-            cursors,
-        };
+        for (const edge of edges) allCursors.push(edge.cursor ?? '');
+
+        if (products.pageInfo.hasNextPage) {
+            return collectCursors(allCursors, edges.at(-1)?.cursor ?? '');
+        }
+
+        return allCursors;
     };
-    const { count: products, cursors } = await countProducts(0);
+
+    const flatCursors = await collectCursors();
+    const products = flatCursors.length;
 
     const perPage = ((extractLimitLikeFilters(filters) as { first?: number })?.first || 30) as number;
     const pages = Math.ceil(products / perPage);
+
+    // The grid asks for `after: cursors[page - 2]`, so page N starts after product (N-1)*perPage.
+    // Slice those boundary cursors out of the flat walk — one per page after the first.
+    const cursors: string[] = [];
+    for (let page = 2; page <= pages; page++) {
+        cursors.push(flatCursors[(page - 1) * perPage - 1] ?? '');
+    }
+
     return {
         pages,
-        cursors: cursors.reverse(),
+        cursors,
         products,
     };
 };

--- a/apps/storefront/src/api/shopify/product/pagination.ts
+++ b/apps/storefront/src/api/shopify/product/pagination.ts
@@ -70,11 +70,17 @@ export const ProductsPaginationCountApi = async ({
     const filters = 'filters' in props ? props.filters : /** @deprecated */ (props as ProductsFilters);
     const filtersTag = JSON.stringify(filters, null, 0);
 
-    const countProducts = async (count: number = 0, cursors: string[] = [], after: string | null = null) => {
+    // Walk the catalog at Shopify's max page size instead of the grid's display size. Relay edge
+    // cursors are position-stable across page sizes for a given sort key, so harvesting every
+    // cursor from a wide walk reconstructs the narrow per-page boundaries while issuing ~7x fewer
+    // serial round-trips (a 35/page display no longer forces ceil(N/35) blocking calls).
+    const TRAVERSAL_PAGE_SIZE = 250;
+
+    const collectCursors = async (allCursors: string[] = [], after: string | null = null): Promise<string[]> => {
         const { data, errors } = await api.query(
             PRODUCTS_PAGINATION_COUNT_QUERY,
             {
-                ...extractLimitLikeFilters(filters),
+                first: TRAVERSAL_PAGE_SIZE,
                 ...(({ sorting = 'BEST_SELLING' }) => ({
                     sorting,
                     after,
@@ -93,33 +99,40 @@ export const ProductsPaginationCountApi = async ({
 
         if (errors) {
             throw new ProviderFetchError(errors);
-        } else if (!data?.products.edges || data.products.edges.length <= 0) {
-            return {
-                count,
-                cursors,
-            };
         }
 
-        const cursor = data.products.edges.at(-1)?.cursor ?? '';
-        if (data.products.pageInfo.hasNextPage) {
-            const res = await countProducts(count, [cursor, ...cursors], cursor);
-
-            count += res.count;
-            cursors = res.cursors;
+        const products = data?.products;
+        const edges = products?.edges;
+        if (!edges || edges.length <= 0) {
+            return allCursors;
         }
 
-        return {
-            count: count + data.products.edges.length,
-            cursors,
-        };
+        for (const edge of edges) allCursors.push(edge.cursor ?? '');
+
+        if (products.pageInfo.hasNextPage) {
+            return collectCursors(allCursors, edges.at(-1)?.cursor ?? '');
+        }
+
+        return allCursors;
     };
-    const { count: products, cursors } = await countProducts(0);
+
+    const flatCursors = await collectCursors();
+    const products = flatCursors.length;
 
     const perPage = ((extractLimitLikeFilters(filters) as { first?: number })?.first || 30) as number;
-    const pages = Math.ceil(products / perPage) - 1; // Subtract 1 because we're using `after` cursors.
+    const pagesCeil = Math.ceil(products / perPage);
+    const pages = pagesCeil - 1; // Subtract 1 because we're using `after` cursors.
+
+    // The grid asks for `after: cursors[page - 2]`; slice the boundary cursor that starts each page
+    // after the first out of the flat walk (one per page that has a next page).
+    const cursors: string[] = [];
+    for (let page = 1; page < pagesCeil; page++) {
+        cursors.push(flatCursors[page * perPage - 1] ?? '');
+    }
+
     return {
         pages,
-        cursors: cursors.reverse(),
+        cursors,
         products,
     };
 };

--- a/apps/storefront/src/app/[domain]/[locale]/cart/cart-sidebar.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/cart/cart-sidebar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCart } from '@nordcom/cart-react';
-import { trace } from '@opentelemetry/api';
 import type { HTMLProps, ReactNode } from 'react';
 import { toast } from 'sonner';
 import { CartSummary } from '@/components/cart/cart-summary';
@@ -80,9 +79,6 @@ export const CartSidebar = ({ i18n, locale, className, children, paymentMethods,
                             trackable: { queueEvent, postEvent },
                         });
                     } catch (error: unknown) {
-                        trace.getActiveSpan()?.addEvent('cart.checkout_failed', {
-                            'error.message': (error as Error)?.message ?? String(error),
-                        });
                         toast.error(error instanceof Error ? error.message : String(error));
                     }
                 }}

--- a/apps/storefront/src/app/[domain]/[locale]/layout.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/layout.tsx
@@ -100,7 +100,12 @@ export default async function RootLayout({
 
     return (
         <html lang={locale.code} className={cn(resolveFontClassName(typography), 'overscroll-x-none')}>
-            <head />
+            <head>
+                {/* Storefront media is served straight from Shopify's image CDN; opening the TLS
+                    connection early shaves the handshake off the first product/hero image fetch. */}
+                <link rel="preconnect" href="https://cdn.shopify.com" crossOrigin="anonymous" />
+                <link rel="dns-prefetch" href="https://cdn.shopify.com" />
+            </head>
             <body className="group/body overflow-x-hidden overscroll-x-none">
                 <Suspense fallback={null}>
                     <CartIsland>

--- a/apps/storefront/src/app/[domain]/[locale]/products/[handle]/product-content.tsx
+++ b/apps/storefront/src/app/[domain]/[locale]/products/[handle]/product-content.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { trace } from '@opentelemetry/api';
 import { ProductProvider } from '@shopify/hydrogen-react';
 import type { ProductVariant, Product as StorefrontProduct } from '@shopify/hydrogen-react/storefront-api-types';
 import { useSearchParams } from 'next/navigation';
@@ -126,10 +125,6 @@ export function ProductSavings({ i18n, product, className }: ProductSavingsProps
 
     const savings = compareAtAmount - totalAmount;
     if (savings < 0) {
-        trace.getActiveSpan()?.addEvent('product.negative_savings', {
-            'product.id': product.id,
-            'product.savings': savings,
-        });
         return null;
     }
 

--- a/apps/storefront/src/components/cart/cart-line.tsx
+++ b/apps/storefront/src/components/cart/cart-line.tsx
@@ -2,7 +2,6 @@
 
 import type { CartLine as CoreCartLine } from '@nordcom/cart-core';
 import { useCartActions, useCartStatus } from '@nordcom/cart-react';
-import { trace } from '@opentelemetry/api';
 import { Tag as TagIcon, X as XIcon } from 'lucide-react';
 import Image from 'next/image';
 import { Button } from '@/components/actionable/button';
@@ -39,9 +38,6 @@ const CartLine = ({ i18n, data: line }: CartLineProps) => {
     const merch = line.merchandise;
 
     if (!merch.productHandle || !merch.id) {
-        trace.getActiveSpan()?.addEvent('cart_line.missing_merchandise', {
-            'cart.line_id': line.id,
-        });
         return null;
     }
 

--- a/apps/storefront/src/components/link.tsx
+++ b/apps/storefront/src/components/link.tsx
@@ -3,7 +3,6 @@
 import type { Url } from 'node:url';
 
 import type { OnlineShop } from '@nordcom/commerce-db';
-import { trace } from '@opentelemetry/api';
 import BaseLink from 'next/link';
 import type { ComponentProps } from 'react';
 import { useShop } from '@/components/shop/provider';
@@ -58,9 +57,6 @@ export default function Link({ locale, href, prefetch, ...props }: LinkProps) {
 
     if (typeof href !== 'string') {
         // TODO: Deal with `URL` as `href`.
-        trace.getActiveSpan()?.addEvent('link.invalid_href_type', {
-            'link.href_type': typeof href,
-        });
         return null;
     }
 
@@ -68,10 +64,7 @@ export default function Link({ locale, href, prefetch, ...props }: LinkProps) {
     let resolvedLocale: Locale;
     try {
         resolvedLocale = locale ?? shop.locale ?? Locale.current ?? Locale.default;
-    } catch (error: unknown) {
-        trace.getActiveSpan()?.addEvent('link.locale_resolution_failed', {
-            'error.message': (error as Error)?.message ?? String(error),
-        });
+    } catch {
         resolvedLocale = Locale.default;
     }
 

--- a/apps/storefront/src/components/live-chat-provider.tsx
+++ b/apps/storefront/src/components/live-chat-provider.tsx
@@ -1,10 +1,16 @@
 'use client';
 
 import type { OnlineShop } from '@nordcom/commerce-db';
+import dynamic from 'next/dynamic';
 import type { ReactNode } from 'react';
-import { Intercom, LiveChatLoaderProvider } from 'react-live-chat-loader';
 import { BuildConfig } from '@/utils/build-config';
 import type { Locale } from '@/utils/locale';
+
+// `react-live-chat-loader` only mounts for production tenants with Intercom configured, so keep it
+// out of the global providers chunk and load it on demand.
+const LiveChatWidget = dynamic(() => import('@/components/live-chat-widget').then((m) => m.LiveChatWidget), {
+    ssr: false,
+});
 
 export type LiveChatProviderProps = {
     shop: OnlineShop;
@@ -35,35 +41,7 @@ export const LiveChatProvider = ({
         <>
             {children}
 
-            {intercom ? (
-                <>
-                    <LiveChatLoaderProvider providerKey={intercom} provider="intercom" idlePeriod={1500}>
-                        <Intercom color={primaryColor?.color} />
-                    </LiveChatLoaderProvider>
-
-                    <script
-                        id="live-chat-intercom"
-                        type="text/javascript"
-                        //strategy="afterInteractive"
-                    >
-                        {`window.intercomSettings = ${JSON.stringify({
-                            api_base: 'https://api-iam.intercom.io',
-                            app_id: intercom,
-                            action_color: primaryColor?.color,
-                            background_color: primaryColor?.color,
-                            hide_default_launcher: false,
-                            // JSON.stringify doesn't escape `</script>`, so an
-                            // admin-editable `intercom` value containing
-                            // `</script><script>...` would have broken out of
-                            // this inline script. Replace `<` with its JS
-                            // unicode escape — valid inside a string literal,
-                            // can't terminate the script element.
-                        }).replace(/</g, '\\u003c')};`}
-                    </script>
-                </>
-            ) : (
-                <div>hello</div>
-            )}
+            <LiveChatWidget intercom={intercom} color={primaryColor?.color} />
         </>
     );
 };

--- a/apps/storefront/src/components/live-chat-widget.tsx
+++ b/apps/storefront/src/components/live-chat-widget.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Intercom, LiveChatLoaderProvider } from 'react-live-chat-loader';
+
+export type LiveChatWidgetProps = {
+    intercom: string;
+    color?: string;
+};
+
+/**
+ * Idle-loaded Intercom widget, split into its own chunk.
+ *
+ * `react-live-chat-loader` is large and only ever mounts for production tenants with Intercom
+ * configured, so {@link import('./live-chat-provider').LiveChatProvider} lazy-mounts this via
+ * `dynamic(..., { ssr: false })` to keep the dependency out of the global providers chunk that
+ * every page ships.
+ *
+ * @param props.intercom - The tenant's Intercom app ID / provider key.
+ * @param props.color - Primary accent color applied to the launcher and inline settings.
+ * @returns The Intercom loader provider plus its inline `intercomSettings` bootstrap script.
+ */
+export const LiveChatWidget = ({ intercom, color }: LiveChatWidgetProps) => {
+    return (
+        <>
+            <LiveChatLoaderProvider providerKey={intercom} provider="intercom" idlePeriod={1500}>
+                <Intercom color={color} />
+            </LiveChatLoaderProvider>
+
+            <script id="live-chat-intercom" type="text/javascript">
+                {`window.intercomSettings = ${JSON.stringify({
+                    api_base: 'https://api-iam.intercom.io',
+                    app_id: intercom,
+                    action_color: color,
+                    background_color: color,
+                    hide_default_launcher: false,
+                    // JSON.stringify doesn't escape `</script>`, so an admin-editable `intercom`
+                    // value containing `</script><script>...` would have broken out of this inline
+                    // script. Replace `<` with its JS unicode escape — valid inside a string
+                    // literal, can't terminate the script element.
+                }).replace(/</g, '\\u003c')};`}
+            </script>
+        </>
+    );
+};
+
+LiveChatWidget.displayName = 'Nordcom.LiveChatWidget';

--- a/apps/storefront/src/components/products/product-gallery-share.tsx
+++ b/apps/storefront/src/components/products/product-gallery-share.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Mail as MailIcon } from 'lucide-react';
+import Image from 'next/image';
+import type { ReactNode } from 'react';
+import { EmailShareButton, FacebookShareButton, TwitterShareButton } from 'react-share';
+
+import type { LocaleDictionary } from '@/utils/locale';
+import { getTranslations } from '@/utils/locale';
+
+const SHARE_BUTTON_STYLES =
+    'focus-ring z-10 flex h-8 w-8 appearance-none items-center justify-center rounded-full border-2 border-(--border-strong) border-solid bg-(--surface-2) text-(color:var(--text)) transition-colors hover:border-(color:var(--accent)) hover:text-(color:var(--accent)) md:h-9 md:w-9';
+
+export type ProductGalleryShareProps = {
+    pageUrl: string;
+    title?: string;
+    i18n: LocaleDictionary;
+    actions?: ReactNode | ReactNode[];
+};
+
+/**
+ * Email/Facebook/X share buttons for the product gallery, split into its own chunk.
+ *
+ * `react-share` pulls a heavy tree of per-network helpers that no longer belongs in the gallery's
+ * initial client bundle. The gallery lazy-mounts this via `dynamic(..., { ssr: false })`, so the
+ * dependency only loads when the share cluster actually renders.
+ *
+ * @param props.pageUrl - Canonical product URL forwarded to each share network.
+ * @param props.title - Share title (SEO title or vendor/title fallback) passed to the buttons.
+ * @param props.i18n - Locale dictionary for the share control labels.
+ * @param props.actions - Additional action nodes rendered below the share buttons.
+ * @returns The vertical stack of share buttons.
+ */
+export const ProductGalleryShare = ({ pageUrl, title, i18n, actions }: ProductGalleryShareProps) => {
+    const { t } = getTranslations('common', i18n);
+
+    return (
+        <div className="flex flex-col gap-2 empty:hidden md:gap-1">
+            <EmailShareButton
+                key="email"
+                url={pageUrl}
+                className={SHARE_BUTTON_STYLES}
+                resetButtonStyle={false}
+                title={title}
+                htmlTitle={t('share-via-email')}
+            >
+                <MailIcon className="stroke-2" />
+            </EmailShareButton>
+            <FacebookShareButton
+                key="facebook"
+                url={pageUrl}
+                className={SHARE_BUTTON_STYLES}
+                resetButtonStyle={false}
+                title={title}
+                htmlTitle={t('share-on-facebook')}
+            >
+                <Image
+                    className="stroke-2"
+                    src="/assets/icons/social/facebook-outline.svg"
+                    alt="Facebook"
+                    width={20}
+                    height={20}
+                />
+            </FacebookShareButton>
+            <TwitterShareButton
+                key="twitter"
+                url={pageUrl}
+                className={SHARE_BUTTON_STYLES}
+                resetButtonStyle={false}
+                title={title}
+                htmlTitle={t('share-on-x')}
+            >
+                <Image
+                    className="stroke-2"
+                    src="/assets/icons/social/twitter-outline.svg"
+                    alt="X (Twitter)"
+                    width={20}
+                    height={20}
+                />
+            </TwitterShareButton>
+
+            {actions}
+        </div>
+    );
+};
+
+ProductGalleryShare.displayName = 'Nordcom.Products.GalleryShare';

--- a/apps/storefront/src/components/products/product-gallery.tsx
+++ b/apps/storefront/src/components/products/product-gallery.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import type { Image as ShopifyImage } from '@shopify/hydrogen-react/storefront-api-types';
-import { Mail as MailIcon } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import type { HTMLProps, ReactNode } from 'react';
-import { Fragment, Suspense, useCallback, useState } from 'react';
-import { EmailShareButton, FacebookShareButton, TwitterShareButton } from 'react-share';
+import { useCallback, useState } from 'react';
 
 import type { Product } from '@/api/product';
 import { ProductGalleryLightbox } from '@/components/products/product-gallery-lightbox';
@@ -13,8 +12,12 @@ import type { LocaleDictionary } from '@/utils/locale';
 import { getTranslations } from '@/utils/locale';
 import { cn } from '@/utils/tailwind';
 
-const SHARE_BUTTON_STYLES =
-    'focus-ring z-10 flex h-8 w-8 appearance-none items-center justify-center rounded-full border-2 border-(--border-strong) border-solid bg-(--surface-2) text-(color:var(--text)) transition-colors hover:border-(color:var(--accent)) hover:text-(color:var(--accent)) md:h-9 md:w-9';
+// `react-share` is heavy and only renders when sharing is enabled, so keep it out of the gallery's
+// initial client chunk and load it on demand.
+const ProductGalleryShare = dynamic(
+    () => import('@/components/products/product-gallery-share').then((m) => m.ProductGalleryShare),
+    { ssr: false },
+);
 
 export type ProductGalleryProps = {
     initialImageId?: string | null;
@@ -113,7 +116,7 @@ const ProductGallery = ({
                             width={image.width ?? 500}
                             height={image.height ?? 500}
                             sizes="(max-width: 920px) 75vw, 500px"
-                            loading="eager"
+                            priority
                             decoding="async"
                             onLoad={() => setLoaded(true)}
                             className={cn(
@@ -132,54 +135,7 @@ const ProductGallery = ({
                                 'hidden md:flex',
                             )}
                         >
-                            <Suspense fallback={<Fragment />}>
-                                <div className="flex flex-col gap-2 empty:hidden md:gap-1">
-                                    <EmailShareButton
-                                        key="email"
-                                        url={pageUrl}
-                                        className={SHARE_BUTTON_STYLES}
-                                        resetButtonStyle={false}
-                                        title={title}
-                                        htmlTitle={t('share-via-email')}
-                                    >
-                                        <MailIcon className="stroke-2" />
-                                    </EmailShareButton>
-                                    <FacebookShareButton
-                                        key="facebook"
-                                        url={pageUrl}
-                                        className={SHARE_BUTTON_STYLES}
-                                        resetButtonStyle={false}
-                                        title={title}
-                                        htmlTitle={t('share-on-facebook')}
-                                    >
-                                        <Image
-                                            className="stroke-2"
-                                            src="/assets/icons/social/facebook-outline.svg"
-                                            alt="Facebook"
-                                            width={20}
-                                            height={20}
-                                        />
-                                    </FacebookShareButton>
-                                    <TwitterShareButton
-                                        key="twitter"
-                                        url={pageUrl}
-                                        className={SHARE_BUTTON_STYLES}
-                                        resetButtonStyle={false}
-                                        title={title}
-                                        htmlTitle={t('share-on-x')}
-                                    >
-                                        <Image
-                                            className="stroke-2"
-                                            src="/assets/icons/social/twitter-outline.svg"
-                                            alt="X (Twitter)"
-                                            width={20}
-                                            height={20}
-                                        />
-                                    </TwitterShareButton>
-
-                                    {actions}
-                                </div>
-                            </Suspense>
+                            <ProductGalleryShare pageUrl={pageUrl} title={title} i18n={i18n} actions={actions} />
 
                             {image.altText ? (
                                 <div className="text-(color:var(--text-muted)) rounded-lg bg-(--surface-1) p-1 px-2 font-semibold text-sm opacity-80">

--- a/apps/storefront/src/components/providers-registry.tsx
+++ b/apps/storefront/src/components/providers-registry.tsx
@@ -2,7 +2,6 @@
 
 import type { OnlineShop } from '@nordcom/commerce-db';
 import { UnknownCommerceProviderError } from '@nordcom/commerce-errors';
-import { trace } from '@opentelemetry/api';
 import { ShopifyProvider } from '@shopify/hydrogen-react';
 import { Fragment, type ReactNode, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -42,9 +41,6 @@ const CommerceProvider = ({ shop, locale, children }: { shop: OnlineShop; locale
                 // TODO: Surface this as a tenant-config validation error during shop lookup.
                 //       For now, render without the Shopify cart provider — content pages still work,
                 //       cart/checkout features will be unavailable.
-                trace.getActiveSpan()?.addEvent('providers_registry.missing_commerce_domain', {
-                    'shop.domain': shop.domain,
-                });
                 return <>{children}</>;
             }
 

--- a/apps/storefront/src/middleware/storefront.ts
+++ b/apps/storefront/src/middleware/storefront.ts
@@ -84,7 +84,14 @@ async function hostnameFromRequest(req: NextRequest): Promise<string> {
  */
 function resolveShopSummary(hostname: string): Promise<ShopResolution> {
     return resolveShop(hostname, async () => {
-        const shop = await Shop.findByDomain(hostname, { sensitiveData: false });
+        // This path only reads `domain` + `i18n.defaultLocale`; project to those two fields so the
+        // existence check never pulls the full tenant document. `convert: false` keeps the raw lean
+        // doc since the masking pipeline expects every field to be present.
+        const shop = await Shop.findByDomain(hostname, {
+            sensitiveData: false,
+            convert: false,
+            projection: { domain: 1, 'i18n.defaultLocale': 1 },
+        });
         if (!shop.domain) {
             throw new NotFoundError(`"Shop" with the handle "${hostname}" cannot be found`);
         }

--- a/apps/storefront/src/utils/request-context.test.ts
+++ b/apps/storefront/src/utils/request-context.test.ts
@@ -10,6 +10,17 @@ vi.mock('@nordcom/commerce-db', () => ({
     },
 }));
 
+// The shop lookup is wrapped in a `'use cache'` helper; stub the cache primitives so the helper
+// runs as a plain async function under vitest.
+vi.mock('next/cache', () => ({
+    cacheLife: vi.fn(),
+    cacheTag: vi.fn(),
+}));
+
+vi.mock('@/cache', () => ({
+    tenantRootTags: vi.fn(() => []),
+}));
+
 const { headers } = await import('next/headers');
 const { Shop } = await import('@nordcom/commerce-db');
 const { getRequestContext } = await import('@/utils/request-context');

--- a/apps/storefront/src/utils/request-context.ts
+++ b/apps/storefront/src/utils/request-context.ts
@@ -1,12 +1,39 @@
 import 'server-only';
 import type { OnlineShop } from '@nordcom/commerce-db';
 import { trace } from '@opentelemetry/api';
+import { cacheLife, cacheTag } from 'next/cache';
 import { headers } from 'next/headers';
 import { cache } from 'react';
 import { Shop } from '@/api/_shop-loader';
+import { tenantRootTags } from '@/cache';
 import { Locale } from '@/utils/locale';
 
 export type RequestContext = { shop: OnlineShop; locale: ReturnType<typeof Locale.from> };
+
+/**
+ * Resolves a tenant's shop document (with feature flags populated) keyed on the primitive
+ * `domain`, cached at `max` and tagged with the tenant-root tags so admin edits evict it.
+ *
+ * `getRequestContext` runs on every request; calling `Shop.findByDomain` directly issued an
+ * uncached, populated mongoose query each time (and its `.exec()` clock read also trips the
+ * prerender current-time guard). Wrapping it in `'use cache'` collapses that to one lookup per
+ * tenant, makes the clock read part of cache creation, and `tenantRootTags(shop)` keeps it fresh.
+ *
+ * @param domain - The tenant hostname to resolve.
+ * @returns The matched shop as `OnlineShop`.
+ * @throws {UnknownShopDomainError} When no shop claims the domain.
+ */
+async function resolveTenantShop(domain: string): Promise<OnlineShop> {
+    'use cache';
+    cacheLife('max');
+
+    const shop = (await Shop.findByDomain(domain, {
+        convert: true,
+        populate: ['featureFlags.flag'],
+    })) as OnlineShop;
+    cacheTag(...tenantRootTags(shop));
+    return shop;
+}
 
 /**
  * Resolves the active shop and locale for the current request from `x-shop-domain` and `x-locale` middleware headers.
@@ -20,10 +47,7 @@ export const getRequestContext = cache(async (): Promise<RequestContext | null> 
         const localeCode = h.get('x-locale');
         if (!domain || !localeCode) return null;
 
-        const shop = await Shop.findByDomain(domain, {
-            convert: true,
-            populate: ['featureFlags.flag'],
-        });
+        const shop = await resolveTenantShop(domain);
         const locale = Locale.from(localeCode);
         if (!shop || !locale) return null;
 

--- a/apps/storefront/src/utils/trackable.tsx
+++ b/apps/storefront/src/utils/trackable.tsx
@@ -4,17 +4,13 @@ import { useMaybeCart } from '@nordcom/cart-react';
 import type { Nullable, OnlineShop, ShopifyCommerceProvider } from '@nordcom/commerce-db';
 import { MissingContextProviderError, TodoError } from '@nordcom/commerce-errors';
 import type { ShopifyPageViewPayload } from '@shopify/hydrogen-react';
-import {
-    AnalyticsEventName as AnalyticsShopifyEventName,
-    getClientBrowserParameters,
-    ShopifySalesChannel,
-    sendShopifyAnalytics,
-    useShop as useShopify,
-    useShopifyCookies,
-} from '@shopify/hydrogen-react';
+// Only the lightweight context hooks are imported statically. The analytics send path
+// (`sendShopifyAnalytics` + `getClientBrowserParameters` and friends) is the heavy part of
+// `@shopify/hydrogen-react`, so it is pulled in via a dynamic `import()` inside the event handler
+// to land in a lazy chunk instead of the initial bundle every page ships.
+import { useShop as useShopify, useShopifyCookies } from '@shopify/hydrogen-react';
 import type { ShopifyContextValue } from '@shopify/hydrogen-react/ShopifyProvider';
 import { track as vercelTrack } from '@vercel/analytics/react';
-import debounce from 'lodash.debounce';
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { Fragment, Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
@@ -160,6 +156,14 @@ const shopifyEventHandler = async (
     } else if (shop.commerceProvider.type !== 'shopify') {
         throw new TodoError('shopifyEventHandler() called for non-Shopify shop.');
     }
+
+    // Lazy-load the analytics surface so it lands in a separate chunk rather than the page bundle.
+    const {
+        AnalyticsEventName: AnalyticsShopifyEventName,
+        getClientBrowserParameters,
+        ShopifySalesChannel,
+        sendShopifyAnalytics,
+    } = await import('@shopify/hydrogen-react');
 
     const commerce = shop.commerceProvider;
     const pageType = pathToShopifyPageType((data.path || '').replace(`/${locale.code}/`, '/'));
@@ -408,6 +412,24 @@ export const NOOP_TRACKABLE_VALUE: TrackableContextValue = {
     queueEvent: () => {},
     postEvent: async () => undefined,
 };
+
+/**
+ * Trailing-edge debounce — coalesces calls within `wait` ms into a single deferred invocation.
+ *
+ * Replaces `lodash.debounce` (the analytics provider's only use of it) with a few lines so the
+ * dependency stays out of the client bundle.
+ *
+ * @param fn - The function to debounce.
+ * @param wait - The quiet period in milliseconds before `fn` runs with the latest arguments.
+ * @returns A debounced wrapper around `fn`.
+ */
+function debounce<Args extends unknown[]>(fn: (...args: Args) => unknown, wait: number) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    return (...args: Args): void => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => fn(...args), wait);
+    };
+}
 
 // Subscribe to `storage` events so a Vercel-toolbar flip in another tab
 // propagates without a reload. The previous no-op `subscribe` meant

--- a/packages/db/src/models/shop.ts
+++ b/packages/db/src/models/shop.ts
@@ -658,6 +658,11 @@ export const ShopSchema = new Schema<ShopBase>(
     },
 );
 
+// `findByDomain` resolves a tenant via `$or: [{ domain }, { alternativeDomains: domain }]` on
+// every request. `domain` is covered by its `unique` index, but the array branch was unindexed,
+// so the `$or` degraded to a full `shops` collection scan that worsens with tenant count.
+ShopSchema.index({ alternativeDomains: 1 });
+
 export const ShopModel = (db.models.Shop || db.model('Shop', ShopSchema)) as ReturnType<
     typeof db.model<typeof ShopSchema>
 >;

--- a/packages/db/src/services/shop.test.ts
+++ b/packages/db/src/services/shop.test.ts
@@ -84,9 +84,26 @@ describe('Shop.findByDomain (Mongoose-backed)', () => {
     it('queries ShopModel.findOne with an $or on domain + alternativeDomains', async () => {
         mockQuery.exec.mockResolvedValueOnce(mockShop);
         await Shop.findByDomain('acme.test');
-        expect(ShopModel.findOne).toHaveBeenCalledWith({
-            $or: [{ domain: 'acme.test' }, { alternativeDomains: 'acme.test' }],
+        expect(ShopModel.findOne).toHaveBeenCalledWith(
+            {
+                $or: [{ domain: 'acme.test' }, { alternativeDomains: 'acme.test' }],
+            },
+            undefined,
+        );
+    });
+
+    it('forwards a field projection to ShopModel.findOne', async () => {
+        mockQuery.exec.mockResolvedValueOnce(mockShop);
+        await Shop.findByDomain('acme.test', {
+            convert: false,
+            projection: { domain: 1, 'i18n.defaultLocale': 1 },
         });
+        expect(ShopModel.findOne).toHaveBeenCalledWith(
+            {
+                $or: [{ domain: 'acme.test' }, { alternativeDomains: 'acme.test' }],
+            },
+            { domain: 1, 'i18n.defaultLocale': 1 },
+        );
     });
 
     it('strips the auth token by default (sensitiveData: false)', async () => {

--- a/packages/db/src/services/shop.ts
+++ b/packages/db/src/services/shop.ts
@@ -23,6 +23,12 @@ export type FindOptions = {
     sensitiveData?: boolean;
     /** Mongoose population paths to apply (e.g. `featureFlags.flag`). */
     populate?: string[];
+    /**
+     * Mongoose field projection (e.g. `{ domain: 1, 'i18n.defaultLocale': 1 }`) so callers that
+     * only read a couple of fields avoid pulling the entire tenant document over the wire. Pair
+     * with `convert: false`; conversion/masking expects a full document.
+     */
+    projection?: Record<string, 0 | 1>;
 };
 
 /**
@@ -115,11 +121,14 @@ export class ShopService extends Service<ShopBase, typeof ShopModel> {
     public async findByDomain(domain: string, options?: FindOptions): Promise<OnlineShop | ShopBase>;
     public async findByDomain(
         domain: string,
-        { sensitiveData = false, convert = true, populate = [] }: FindOptions = {},
+        { sensitiveData = false, convert = true, populate = [], projection }: FindOptions = {},
     ): Promise<OnlineShop | ShopBase> {
-        let query = ShopModel.findOne({
-            $or: [{ domain }, { alternativeDomains: domain }],
-        });
+        let query = ShopModel.findOne(
+            {
+                $or: [{ domain }, { alternativeDomains: domain }],
+            },
+            projection,
+        );
         for (const path of populate) query = query.populate(path);
         const doc = await query.lean<ShopBase>().exec();
 


### PR DESCRIPTION
…ByDomain.

The tenant resolver runs `findByDomain` on every request via `$or: [{ domain }, { alternativeDomains }]`. Only `domain` carried an index, so the array branch forced a full `shops` collection scan that worsens with tenant count. Add an index on `alternativeDomains` and a `projection` option so callers that read a couple of fields stop pulling the whole tenant document.