### PR TITLE
fix(changeset): drop the orphan tagtree-payload changeset

### DIFF
--- a/.changeset/jsdoc-tagtree-payload.md
+++ b/.changeset/jsdoc-tagtree-payload.md
@@ -1,5 +1,0 @@
----
-'@tagtree/payload': patch
----
-
-Backfill JSDoc on public/internal symbols.


### PR DESCRIPTION
## Why

`changeset version` was failing CI:

```
🦋  error Error: Found changeset jsdoc-tagtree-payload for package @tagtree/payload which is not in the workspace
```

`@tagtree/payload` was removed in `07b9cd5bf feat(teardown): remove the full payload application surface.`, but its JSDoc changeset stayed behind. Changesets chokes on a changeset targeting a package not in the workspace.

## What

Delete the orphan `.changeset/jsdoc-tagtree-payload.md`.

`changeset status` is clean after the removal.